### PR TITLE
fix: bash 設定のクロスプラットフォーム互換性を改善

### DIFF
--- a/.bashrc.d/00-env.sh
+++ b/.bashrc.d/00-env.sh
@@ -5,7 +5,7 @@ export PAGER='less'
 umask 022
 
 export PYTHONDONTWRITEBYTECODE=1
-export SHELL='/bin/bash'
+export SHELL="${BASH:-/bin/bash}"
 
 # Locale settings.
 export LC_ALL='en_US.UTF-8'

--- a/.bashrc.d/20-path.sh
+++ b/.bashrc.d/20-path.sh
@@ -1,28 +1,28 @@
 # shellcheck shell=bash
 
 # Keep system administration directories available.
-path_prepend '/sbin'
-path_prepend '/usr/sbin'
+[ -d '/sbin' ]      && path_prepend '/sbin'
+[ -d '/usr/sbin' ]  && path_prepend '/usr/sbin'
 
 # Toolchains and package managers.
-path_prepend '/opt/local/bin'
-path_prepend '/opt/local/sbin'
-path_prepend '/usr/local/texlive/2022/bin/universal-darwin'
-path_prepend "$HOME/.local/bin"
-path_prepend "$HOME/.nodebrew/current/bin"
-path_prepend "$HOME/anaconda3/bin"
-path_prepend "$HOME/.pyenv/bin"
-path_prepend '/opt/poetry/bin'
-path_append '/usr/local/go/bin'
+[ -d '/opt/local/bin' ]                                        && path_prepend '/opt/local/bin'
+[ -d '/opt/local/sbin' ]                                       && path_prepend '/opt/local/sbin'
+[ -d '/usr/local/texlive/2022/bin/universal-darwin' ]          && path_prepend '/usr/local/texlive/2022/bin/universal-darwin'
+[ -d "$HOME/.local/bin" ]                                      && path_prepend "$HOME/.local/bin"
+[ -d "$HOME/.nodebrew/current/bin" ]                           && path_prepend "$HOME/.nodebrew/current/bin"
+[ -d "$HOME/anaconda3/bin" ]                                   && path_prepend "$HOME/anaconda3/bin"
+[ -d "$HOME/.pyenv/bin" ]                                      && path_prepend "$HOME/.pyenv/bin"
+[ -d '/opt/poetry/bin' ]                                       && path_prepend '/opt/poetry/bin'
+[ -d '/usr/local/go/bin' ]                                     && path_append  '/usr/local/go/bin'
 
 # Go workspace bins.
-path_prepend "$HOME/go/bin"
-path_prepend "$HOME/go/ugo/bin"
-path_prepend "$HOME/go/go_test/bin"
+[ -d "$HOME/go/bin" ]          && path_prepend "$HOME/go/bin"
+[ -d "$HOME/go/ugo/bin" ]      && path_prepend "$HOME/go/ugo/bin"
+[ -d "$HOME/go/go_test/bin" ]  && path_prepend "$HOME/go/go_test/bin"
 
 # User utilities.
-path_append "$HOME/.pulumi/bin"
-path_append '/opt/homebrew/share/git-core/contrib/diff-highlight'
+[ -d "$HOME/.pulumi/bin" ]                                              && path_append "$HOME/.pulumi/bin"
+[ -d '/opt/homebrew/share/git-core/contrib/diff-highlight' ]            && path_append '/opt/homebrew/share/git-core/contrib/diff-highlight'
 
 export PATH
 export MANPATH="/opt/local/man:${MANPATH:-}"

--- a/.bashrc.d/70-tools.sh
+++ b/.bashrc.d/70-tools.sh
@@ -28,7 +28,11 @@ if command -v trash-put >/dev/null 2>&1; then
   alias rm='trash-put'
 fi
 
-# Set DISPLAY only on Linux (not macOS or WSL2 which manages it separately).
-if [[ "$(uname -s)" == "Linux" ]] && [[ -z "${WAYLAND_DISPLAY:-}" ]] && [[ -z "${DISPLAY:-}" ]]; then
+# Set DISPLAY only on Linux X11 (not macOS, Wayland, or WSL which manages it separately).
+if [[ "$(uname -s)" == "Linux" ]] \
+  && [[ -z "${WAYLAND_DISPLAY:-}" ]] \
+  && [[ -z "${DISPLAY:-}" ]] \
+  && [[ -z "${WSL_DISTRO_NAME:-}" ]] \
+  && [[ -z "${WSL_INTEROP:-}" ]]; then
   export DISPLAY=':0'
 fi

--- a/.bashrc.d/70-tools.sh
+++ b/.bashrc.d/70-tools.sh
@@ -28,4 +28,7 @@ if command -v trash-put >/dev/null 2>&1; then
   alias rm='trash-put'
 fi
 
-export DISPLAY=':0'
+# Set DISPLAY only on Linux (not macOS or WSL2 which manages it separately).
+if [[ "$(uname -s)" == "Linux" ]] && [[ -z "${WAYLAND_DISPLAY:-}" ]] && [[ -z "${DISPLAY:-}" ]]; then
+  export DISPLAY=':0'
+fi


### PR DESCRIPTION
## 概要
macOS・Linux・WSL 環境で bash 設定が正しく動作するよう、3 箇所の互換性問題を修正。

## 変更内容
- [x] バグ修正

## 修正詳細
- `20-path.sh`: 全 PATH エントリに `[ -d ... ]` による存在チェックを追加。
  zsh 側（`30-path.zsh`）は既に `[[ -d ]] && path+=()` で存在確認していたが、
  bash 側は無条件追加だったため PATH が汚染されていた。
- `70-tools.sh`: `export DISPLAY=':0'` を Linux X11 環境限定に変更。
  macOS は Window Server が自動設定するため上書きすると問題になり、
  WSL2 は動的なアドレスが必要なため `:0` のハードコードは不適切だった。
- `00-env.sh`: `SHELL='/bin/bash'` を `${BASH:-/bin/bash}` に変更し、
  実際のインタープリタパスを反映するよう修正。

## レビューのポイント
- `DISPLAY` の条件は `uname -s == Linux` かつ `WAYLAND_DISPLAY` 未設定かつ `DISPLAY` 未設定の場合のみ設定。Wayland 環境や既に DISPLAY が設定済みの場合は上書きしない。
- zsh 設定（`.zshrc.d/`）は既に適切に実装されており変更なし。

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [x] `bash -n` による構文チェック済み