### PR TITLE
feat: mise をランタイムバージョンマネージャとして統合

### DIFF
--- a/.bashrc.d/20-path.sh
+++ b/.bashrc.d/20-path.sh
@@ -9,9 +9,7 @@
 [ -d '/opt/local/sbin' ]                                       && path_prepend '/opt/local/sbin'
 [ -d '/usr/local/texlive/2022/bin/universal-darwin' ]          && path_prepend '/usr/local/texlive/2022/bin/universal-darwin'
 [ -d "$HOME/.local/bin" ]                                      && path_prepend "$HOME/.local/bin"
-[ -d "$HOME/.nodebrew/current/bin" ]                           && path_prepend "$HOME/.nodebrew/current/bin"
 [ -d "$HOME/anaconda3/bin" ]                                   && path_prepend "$HOME/anaconda3/bin"
-[ -d "$HOME/.pyenv/bin" ]                                      && path_prepend "$HOME/.pyenv/bin"
 [ -d '/opt/poetry/bin' ]                                       && path_prepend '/opt/poetry/bin'
 [ -d '/usr/local/go/bin' ]                                     && path_append  '/usr/local/go/bin'
 
@@ -27,7 +25,6 @@
 export PATH
 export MANPATH="/opt/local/man:${MANPATH:-}"
 
-export PYENV_ROOT="$HOME/.pyenv"
 export GOPATH="$HOME/go:$HOME/go/ugo:$HOME/go/go_test"
 
 if command -v go >/dev/null 2>&1; then

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,16 @@
+# mise global tool versions
+# https://mise.jdx.dev/
+#
+# Run `mise install` after symlinking this file to apply all tools.
+# Run `mise use --global <tool>@<version>` to update a version.
+
+[tools]
+python = "3.12"
+node   = "lts"
+go     = "latest"
+
+[settings]
+# Also read .tool-versions files (asdf compatibility)
+legacy_version_file = true
+# Auto-install missing tools when entering a directory
+auto_install = true

--- a/.zshrc.d/30-path.zsh
+++ b/.zshrc.d/30-path.zsh
@@ -1,5 +1,4 @@
 # shellcheck shell=zsh
-export PYENV_ROOT="$HOME/.pyenv"
 export GOPATH="$HOME/go:$HOME/go/ugo:$HOME/go/go_test"
 if command -v go >/dev/null 2>&1; then
   # shellcheck disable=SC2155
@@ -17,13 +16,11 @@ path=(
 
 [[ -d /opt/local/bin ]]                         && path+=(/opt/local/bin)
 [[ -d /opt/local/sbin ]]                        && path+=(/opt/local/sbin)
-[[ -d "$HOME/.nodebrew/current/bin" ]]          && path+=("$HOME/.nodebrew/current/bin")
 [[ -d "$HOME/anaconda3/bin" ]]                  && path+=("$HOME/anaconda3/bin")
 [[ -d "$HOME/go/bin" ]]                         && path+=("$HOME/go/bin")
 [[ -d "$HOME/go/ugo/bin" ]]                     && path+=("$HOME/go/ugo/bin")
 [[ -d "$HOME/go/go_test/bin" ]]                 && path+=("$HOME/go/go_test/bin")
 [[ -d "$HOME/.local/bin" ]]                     && path+=("$HOME/.local/bin")
-[[ -d "$PYENV_ROOT/bin" ]]                      && path+=("$PYENV_ROOT/bin")
 [[ -d /opt/poetry/bin ]]                        && path+=(/opt/poetry/bin)
 [[ -d "$HOME/.pulumi/bin" ]]                    && path+=("$HOME/.pulumi/bin")
 [[ -d "$HOME/.cargo/bin" ]]                     && path+=("$HOME/.cargo/bin")

--- a/.zshrc.d/70-tools.zsh
+++ b/.zshrc.d/70-tools.zsh
@@ -19,8 +19,5 @@ export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -200'"
 # autojump
 [[ -s "$HOME/.autojump/etc/profile.d/autojump.sh" ]] && source "$HOME/.autojump/etc/profile.d/autojump.sh"
 
-# mise
-command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
-
 # kubectl completion
 command -v kubectl >/dev/null 2>&1 && source <(kubectl completion zsh)

--- a/.zshrc.d/70-tools.zsh
+++ b/.zshrc.d/70-tools.zsh
@@ -1,15 +1,11 @@
 # shellcheck shell=zsh
 # shellcheck disable=SC1090
-# nvm
-export NVM_DIR="$HOME/.nvm"
-[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"
-[[ -s "$NVM_DIR/bash_completion" ]] && . "$NVM_DIR/bash_completion"
 
 # deno
 [[ -f "$HOME/.deno/env" ]] && . "$HOME/.deno/env"
 
-# pyenv
-command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init -)"
+# mise (manages python, node, go, etc.)
+command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
 
 # fzf
 [[ -f "$HOME/.fzf.zsh" ]] && source "$HOME/.fzf.zsh"

--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,17 @@ for f in .??*; do
   [[ "$f" == ".DS_Store" ]] && continue
   [[ "$f" == ".github" ]]   && continue
   [[ "$f" == ".codex" ]]    && continue
+  [[ "$f" == ".config" ]]   && continue  # managed per-file below
   symlink "$SCRIPT_DIR/$f" "$HOME/$f"
 done
+
+# ---------------------------------------------------------------------------
+# mise: global tool config
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Linking mise global config"
+run mkdir -p "$HOME/.config/mise"
+symlink "$SCRIPT_DIR/.config/mise/config.toml" "$HOME/.config/mise/config.toml"
 
 # ---------------------------------------------------------------------------
 # Git config


### PR DESCRIPTION
## 概要
pyenv / nvm / nodebrew を mise に一本化し、グローバルツール設定を dotfiles で管理できるようにする。

## 関連Issue
Closes #

## 変更内容
- [x] 機能追加（mise グローバル設定ファイル追加）
- [x] リファクタリング（不要な PATH エントリ・init コードの削除）
- [x] バグ修正
- [ ] ドキュメント更新

## 修正詳細
- `.config/mise/config.toml` を新規追加。python 3.12 / node lts / go latest をグローバル定義。
- `install.sh`: `.config/` を一括シンボリックリンク対象から除外し、mise config のみ個別にリンク（`~/.config/` 全体を上書きしない）。
- `70-tools.zsh`: nvm 初期化・pyenv init を削除し `mise activate zsh` に一本化。
- `70-tools.zsh`: 二重に定義されていた `mise activate zsh`（22–23行目）を削除し、7–8行目の一か所のみに統一。
- `30-path.zsh` / `20-path.sh`: `PYENV_ROOT`・pyenv/bin・nodebrew/bin の PATH エントリを削除（mise shims が代替）。

## セットアップ手順
```bash
./install.sh   # ~/.config/mise/config.toml がシンボリックリンクされる
mise install   # python / node / go を一括インストール
```

## スクリーンショット・デモ
| Before | After |
| :--- | :--- |
| ![Before](URL) | ![After](URL) |

## レビューのポイント
- anaconda3 は conda エコシステムが mise と独立しているため残している。
- Go の GOPATH・ワークスペース bin は mise 管轄外のため残している。
- bash 側 (`70-tools.sh`) の mise activation は既存のまま（`/home/gvatech231/.local/bin/mise` チェック付き）。

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した