### PR TITLE
docs(skills): pull-request スキルにデフォルトブランチ検出の手順を追記

### DIFF
--- a/.github/skills/pull-request/SKILL.md
+++ b/.github/skills/pull-request/SKILL.md
@@ -27,6 +27,26 @@ git --no-pager log main..HEAD --oneline
 
 未コミットの変更がある場合はユーザーに確認してから続行。
 
+**デフォルトブランチにいる場合は新しいブランチを作成する。**
+
+現在のブランチがデフォルトブランチ（`main` / `master`）と一致する場合は、
+コミット内容から適切なブランチ名を生成して切り替えてから PR を作成する。
+
+```bash
+# デフォルトブランチの確認
+default_branch=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+current_branch=$(git branch --show-current)
+
+# デフォルトブランチにいる場合は新ブランチを作成
+if [ "$current_branch" = "$default_branch" ]; then
+  # コミット内容から <type>/<short-description> 形式でブランチ名を決める
+  git checkout -b <type>/<short-description>
+fi
+```
+
+ブランチ名の命名規則: `<type>/<kebab-case-description>`
+例: `feat/add-mise-config`、`fix/bash-display-guard`、`docs/update-readme`
+
 ### 2. 差分の調査
 
 ```bash


### PR DESCRIPTION
## 概要
デフォルトブランチ（main/master）上で PR を作成しようとした場合に、
適切なブランチを自動作成してから PR を出すよう手順を明示。

## 変更内容
- [ ] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新

## 修正詳細
- 手順 1 に「デフォルトブランチにいる場合は新ブランチを作成する」セクションを追加
- `gh repo view` でデフォルトブランチを動的に確認するコマンド例を追記
- ブランチ名命名規則（`<type>/<kebab-case-description>`）と例を記載

## レビューのポイント
今回のセッションで master 上でコミットしてから PR を作った際に手順が抜けていたため追記。

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [x] 新しい機能はドキュメントを更新した