### PR TITLE
chore: .tmux.conf の末尾スペースと不要なコメントを削除

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -123,7 +123,7 @@ set -g @continuum-restore 'on'
 # Plugins
 set -g @plugin 'tmux-plugins/tpm'
 
-# Initialize TMUX plugin manager 
+# Initialize TMUX plugin manager
 # (keep this line at the very bottom of tmux.conf)
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
@@ -138,7 +138,7 @@ run '~/.tmux/plugins/tpm/tpm'
 if-shell 'uname | grep -q Darwin' {
     # Macでtmuxのクリップボード操作を有効化
     set-option -g default-command "reattach-to-user-namespace -l zsh"
-    
+
     # コピーモードで選択範囲をクリップボードにコピーする設定
     bind-key -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
     bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
@@ -169,53 +169,3 @@ if-shell 'grep -qi Microsoft /proc/version' {
 
 # prefix + space を無効化（画面を整列することはない）
 unbind Space
-
-# # 240418: wsl + tmux 上でのヤンククリップボード共有設定
-# # wsl + ubuntuだと特に必要なかったが、wsl + arch linux だと必要
-# # win32yankが必要
-# # このほかに.vimrcの設定が必要
-# # 参考: https://zenn.dev/kujirahand/articles/4b37160f781be7
-# # --- wsl (win32yank) ---
-# # https://github.com/equalsraf/win32yank
-# if "which win32yank.exe" "bind-key -T copy-mode-vi y     send-keys -X copy-p    ipe-and-cancel 'win32yank.exe -i'"
-# if "which win32yank.exe" "bind-key -T copy-mode-vi Enter send-keys -X copy-p    ipe-and-cancel 'win32yank.exe -i'"
-# # pでペースト
-# if "which win32yank.exe" "bind-key P run 'tmux set-buffer -- \"$(win32yank.e    xe -o)\"; tmux paste-buffer'"
-# # macOS
-# if-shell 'uname | grep -q Darwin' {
-#     # Macでtmuxのクリップボード操作を有効化
-#     set-option -g default-command "reattach-to-user-namespace -l zsh"
-#     
-#     # コピーモードで選択範囲をクリップボードにコピーする設定
-#     bind-key -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-#     bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-# }
-# 
-# # Linux
-# if-shell 'uname | grep -q Linux' {
-# }
-# 
-# # WSL
-# if-shell 'grep -qi Microsoft /proc/version' {
-#     # WSL 用の設定
-# 
-#     # 240418: wsl + tmux 上でのヤンククリップボード共有設定
-#     # このほかに.vimrcの設定が必要
-#     # 参考: https://zenn.dev/kujirahand/articles/4b37160f781be7
-#     # --- wsl (win32yank) ---
-#     # https://github.com/equalsraf/win32yank
-# 
-#     if "which win32yank.exe" "bind-key -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel 'win32yank.exe -i'"
-#     if "which win32yank.exe" "bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'win32yank.exe -i'"
-# 
-#     # pでペースト
-#     # if "which win32yank.exe" "bind-key p run 'tmux set-buffer -- \"$(win32yank.exe -o)\"; tmux paste-buffer'"
-#     # 制御文字削除 => 効いていない
-#     if "which win32yank.exe" "bind-key P run 'tmux set-buffer -- \"$(win32yank.exe -o | tr -d \"\\r\")\"; tmux paste-buffer'"
-#     # wsl copy mode
-#     # bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "win32yank.exe -i"
-# 
-# # Windows clipboard -> tmux -> shell（^M 完全排除）
-# }
-# 
-# 


### PR DESCRIPTION
## 概要
.tmux.conf の軽微なクリーンアップ。末尾の余分なスペースを除去し、古い win32yank (WSL) クリップボード設定のコメントアウトブロックを削除。

## 関連Issue
Closes #

## 変更内容
- [ ] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新

## 修正詳細
- 末尾スペースを 2 箇所削除（コメント行・空行）
- 旧 win32yank + WSL クリップボード設定のコメントアウトブロック（約50行）を削除（現行の WSL セクションと重複しており不要）

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した