### PR TITLE
refactor(aliases): refresh-default-branch を強化し alias 重複を除去

### DIFF
--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -247,7 +247,6 @@ alias gwp='git worktree prune'
 refresh-default-branch() {
   local default_branch
 
-  # デフォルトブランチ名を取得
   default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 
   if [ -z "$default_branch" ]; then
@@ -260,24 +259,43 @@ refresh-default-branch() {
   # デフォルトブランチへ移動
   git checkout "${default_branch}" || return 1
 
-  # pull 実行
+  # 最新化
   if ! git pull origin "${default_branch}"; then
     echo "git pull に失敗したため rebase を試行します"
     git pull --rebase origin "${default_branch}" || return 1
   fi
 
-  # merge-worktrees ブランチを削除
+  # リモート追跡ブランチを整理
+  echo "不要な追跡ブランチを削除します"
+  git fetch --prune origin || return 1
+
+  # merge-worktrees を削除（存在する場合）
   if git show-ref --verify --quiet refs/heads/merge-worktrees; then
     echo "merge-worktrees を削除"
     git branch -D merge-worktrees || return 1
   fi
 
-  # merge-worktrees ブランチを作成
+  # マージ済みローカルブランチを削除
+  echo "マージ済みブランチを削除します"
+
+  git branch --merged |
+    sed 's/^[* ]*//' |
+    grep -v "^${default_branch}$" |
+    grep -v "^merge-worktrees$" |
+    while read -r branch; do
+      [ -z "$branch" ] && continue
+
+      echo "delete merged branch: ${branch}"
+      git branch -d "${branch}"
+    done
+
+  # merge-worktrees を再作成
   echo "merge-worktrees を作成"
   git checkout -b merge-worktrees || return 1
 
   echo "merge-worktrees ブランチの準備が完了しました"
 }
+
 
 # tmux
 alias ta='tmux a -t'

--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -29,8 +29,6 @@ alias cwt='cargo watch -x test'
 
 alias tiga='tig --all'
 
-alias c='copilot --yolo'
-
 # vim
 alias v='nvim'
 alias vi='nvim'


### PR DESCRIPTION
## 概要
`refresh-default-branch` 関数にマージ済みブランチの一括削除とリモート追跡ブランチの整理を追加し、末尾に残っていた alias の重複を除去する。

## 変更内容
- [ ] 機能追加
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新

## 修正詳細
- `.zsh_aliases`:
  - `alias c='copilot --yolo'` の重複定義（29行目付近）を削除
  - `refresh-default-branch` に `git fetch --prune origin` を追加してリモート追跡ブランチを整理
  - マージ済みのローカルブランチを一括削除するループを追加
  - コメントを簡潔に整理

## レビューのポイント
- `refresh-default-branch` は `master` または `main` に戻ったあと `merge-worktrees` ブランチを再作成する便利関数。今回のマージ済みブランチ削除ループが意図通り動作するか確認してほしい。
- `alias c` は 14 行目の定義が残っているため機能に影響なし。

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した