### PR TITLE
feat(mise): neovim をマネージドツールに追加

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -13,6 +13,7 @@ poetry = "latest"
 awscli  = "latest"
 hurl    = "latest"
 kubectl = "latest"
+neovim  = "latest"
 copilot = "latest"
 
 [env]


### PR DESCRIPTION
## 概要
`mise` で neovim を管理できるよう `.config/mise/config.toml` に追加する。

## 変更内容
- [x] 機能追加

## 修正詳細
- `.config/mise/config.toml`: `neovim = "latest"` を追加

## レビューのポイント
- mise の neovim プラグインは `vfox:mise-plugins/vfox-neovim` / `aqua:neovim/neovim` が利用可能。`mise install` で最新版がインストールされる。

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した