### PR TITLE
fix(nvim): lspconfig 非推奨 API を vim.lsp.config に移行

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -13,6 +13,7 @@ poetry = "latest"
 awscli  = "latest"
 hurl    = "latest"
 kubectl = "latest"
+neovim  = "latest"
 copilot = "latest"
 
 [env]

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -13,6 +13,7 @@ poetry = "latest"
 awscli  = "latest"
 hurl    = "latest"
 kubectl = "latest"
+tmux    = "latest"
 copilot = "latest"
 
 [env]

--- a/.vimrc
+++ b/.vimrc
@@ -279,11 +279,12 @@ cmp.setup.cmdline(':', {
   }
 })
 
--- LSPサーバーの設定（例：nvim-lspconfigを使用）
+-- LSPサーバーの設定
 local capabilities = require('cmp_nvim_lsp').default_capabilities()
-require('lspconfig')['pyright'].setup {
-  capabilities = capabilities
-}
+vim.lsp.config('pyright', {
+  capabilities = capabilities,
+})
+vim.lsp.enable('pyright')
 EOF
 
 


### PR DESCRIPTION
## 概要
nvim 起動時に表示される `require('lspconfig')` 非推奨警告を解消するため、
新しい `vim.lsp.config` API に移行する。

## 変更内容
- [x] バグ修正

## 修正詳細
- `.vimrc`:
  - `require('lspconfig')['pyright'].setup{}` を `vim.lsp.config('pyright', {})` + `vim.lsp.enable('pyright')` に書き換え

## レビューのポイント
- neovim 0.11.6 で動作確認済み
- nvim-lspconfig v3.0.0 で旧 API が削除される前に対応

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した