### PR TITLE
refactor: vim プラグイン整理・競合解消・バグ修正

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -166,74 +166,58 @@ Plug 'rust-lang/rust.vim'
 
 call plug#end()
 
-""""""""""""""""""""""""""""""""""""""""""""""
 " Telescopeの設定
 lua << EOF
-require('telescope').setup {}
+local ok, telescope = pcall(require, 'telescope')
+if ok then telescope.setup {} end
 EOF
 
 " Lualineの設定
 lua << EOF
-require('lualine').setup {
-  options = { theme = 'gruvbox' },
-}
+local ok, lualine = pcall(require, 'lualine')
+if ok then lualine.setup { options = { theme = 'gruvbox' } } end
 EOF
 
-" Nvim-treeの設定 
+" Nvim-treeの設定
 lua << EOF
-
-require('nvim-tree').setup({
-  view = {
-    -- width = 31,  -- 必要に応じてツリーの幅を調整
-    float = {
-          enable = true, -- フロートウィンドウモードを有効化
-          open_win_config = {
-            relative = "editor", -- エディタ全体に対する位置
-            border = "rounded",  -- ウィンドウの枠のスタイル ("rounded", "single", "double", "none")
-            width = 90,          -- フロートウィンドウの幅
-            height = 50,         -- フロートウィンドウの高さ
-            row = 3,             -- エディタ上部からの相対位置
-            col = 10,            -- エディタ左端からの相対位置
-          },
-      },
-  },
-  -- ファイルツリーが開かれた際にカスタムキーマッピングを設定
-  -- on_attach = function(bufnr)
-  --   local api = require('nvim-tree.api')
-
-  --   -- キーマッピング設定
-  --   local opts = { noremap = true, silent = true, nowait = true, buffer = bufnr }
-
-  --   -- "s"キーで垂直分割してファイルを開く
-  --   vim.keymap.set('n', 's', api.node.open.vertical, opts)
-
-  --   -- "i"キーで水平分割してファイルを開く
-  --   vim.keymap.set('n', 'i', api.node.open.horizontal, opts)
-  -- end,
-})
-
+local ok, nvim_tree = pcall(require, 'nvim-tree')
+if ok then
+  nvim_tree.setup({
+    view = {
+      float = {
+            enable = true,
+            open_win_config = {
+              relative = "editor",
+              border = "rounded",
+              width = 90,
+              height = 50,
+              row = 3,
+              col = 10,
+            },
+        },
+    },
+  })
+end
 EOF
 
 " Treesitterの設定
 lua <<EOF
-require'nvim-treesitter.configs'.setup {
-  ensure_installed = { "svelte", "html", "css", "javascript",
-"typescript" },
-  highlight = {
-    enable = true,
-    additional_vim_regex_highlighting = { "python" },
-    disable = { 'lua' }
+local ok, configs = pcall(require, 'nvim-treesitter.configs')
+if ok then
+  configs.setup {
+    ensure_installed = { "svelte", "html", "css", "javascript", "typescript" },
+    highlight = {
+      enable = true,
+      additional_vim_regex_highlighting = { "python" },
+      disable = { 'lua' }
+    }
   }
-}
+end
 EOF
 
-
 lua << EOF
-require'nvim-web-devicons'.setup {
-  -- global default (default to false)
-  -- will get overridden by `get_icons` option
-  default = true;
-}
+local ok, devicons = pcall(require, 'nvim-web-devicons')
+if ok then devicons.setup { default = true } end
 EOF
 
 " colorscheme lucius
@@ -245,18 +229,17 @@ let g:onedark_config = {
 " comment の色を修正
 " これだけでは不十分で以下のshellなどの設定も別途追加
 lua << EOF
-require('onedark').setup {
-  colors = {
-    bright_orange = "#ff8800",
-  },
-  highlights = {
-    ["@comment"] = {fg = '#8F917F'},
-    -- ["@keyword"] = {fg = '$green'},
-    -- ["@string"] = {fg = '$bright_orange', bg = '#00ff00', fmt = 'bold'},
-    -- ["@function"] = {fg = '#0000ff', sp = '$cyan', fmt = 'underline,italic'},
-    -- ["@function.builtin"] = {fg = '#0059ff'}
+local ok, onedark = pcall(require, 'onedark')
+if ok then
+  onedark.setup {
+    colors = {
+      bright_orange = "#ff8800",
+    },
+    highlights = {
+      ["@comment"] = {fg = '#8F917F'},
+    }
   }
-}
+end
 EOF
 
 let g:copilot_settings = #{selectedCompletionModel: 'gpt-4o-copilot'}

--- a/.vimrc
+++ b/.vimrc
@@ -11,9 +11,7 @@ set softtabstop=4
 set autoindent
 set smartindent
 set smarttab
-set shiftwidth=4
 set cursorline
-set hlsearch
 set scrolloff=5
 set encoding=utf-8
 
@@ -134,15 +132,9 @@ set foldlevel=4
 
 call plug#begin('~/.config/nvim/plugged')
 
-Plug 'iamcco/markdown-preview.nvim', { 'do': 'cd app & yarn install'  }
+Plug 'iamcco/markdown-preview.nvim', { 'do': { -> mkdp#util#install() } }
 Plug 'junegunn/vim-easy-align'
 Plug 'mechatroner/rainbow_csv'
-
-Plug 'psf/black', { 'branch': 'stable' }
-
-Plug 'preservim/nerdtree'
-
-Plug 'ctrlpvim/ctrlp.vim'
 
 Plug 'neoclide/coc.nvim', {'branch': 'release'}
 
@@ -164,15 +156,7 @@ Plug 'nvim-tree/nvim-web-devicons'
 " シンタックスハイライト
 Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
 
-" 自動補完
-Plug 'hrsh7th/nvim-cmp'         " nvim-cmp本体
-Plug 'hrsh7th/cmp-nvim-lsp'     " LSP補完
-Plug 'hrsh7th/cmp-buffer'       " バッファ補完
-Plug 'hrsh7th/cmp-path'         " パス補完
-Plug 'hrsh7th/cmp-cmdline'      " コマンドライン補完
-Plug 'L3MON4D3/LuaSnip'         " スニペットエンジン
-Plug 'saadparwaiz1/cmp_luasnip' " LuaSnipとの連携
-Plug 'neovim/nvim-lspconfig'
+" 自動補完 (coc.nvim が担当)
 
 " highlight
 Plug 'navarasu/onedark.nvim'
@@ -244,51 +228,6 @@ require'nvim-treesitter.configs'.setup {
 EOF
 
 
-" 自動補完の設定
-lua << EOF
-local cmp = require'cmp'
-
--- cmpの設定
-cmp.setup({
-  snippet = {
-    expand = function(args)
-      require('luasnip').lsp_expand(args.body) -- LuaSnipをスニペットエンジンとして使用
-    end,
-  },
-  mapping = {
-    ['<C-n>'] = cmp.mapping.select_next_item(), -- 次の補完候補を選択
-    ['<C-p>'] = cmp.mapping.select_prev_item(), -- 前の補完候補を選択
-    ['<CR>'] = cmp.mapping.confirm({ select = true }), -- Enterで補完を確定
-    -- ['<C-Space>'] = cmp.mapping.complete(), -- 手動で補完を呼び出し
-  },
-  sources = cmp.config.sources({
-    { name = 'nvim_lsp' }, -- LSPからの補完
-    { name = 'luasnip' },  -- スニペットからの補完
-  }, {
-    { name = 'buffer' },   -- バッファからの補完
-    { name = 'path' },     -- パス補完
-  })
-})
-
--- コマンドラインの補完設定
-cmp.setup.cmdline(':', {
-  mapping = cmp.mapping.preset.cmdline(),
-  sources = {
-    { name = 'path' },      -- パス補完
-    { name = 'cmdline' }    -- コマンドライン補完
-  }
-})
-
--- LSPサーバーの設定
-local capabilities = require('cmp_nvim_lsp').default_capabilities()
-vim.lsp.config('pyright', {
-  capabilities = capabilities,
-})
-vim.lsp.enable('pyright')
-EOF
-
-
-
 lua << EOF
 require'nvim-web-devicons'.setup {
   -- global default (default to false)
@@ -311,7 +250,7 @@ require('onedark').setup {
     bright_orange = "#ff8800",
   },
   highlights = {
-    ["@comment"] = {fg = '##8F917F'},
+    ["@comment"] = {fg = '#8F917F'},
     -- ["@keyword"] = {fg = '$green'},
     -- ["@string"] = {fg = '$bright_orange', bg = '#00ff00', fmt = 'bold'},
     -- ["@function"] = {fg = '#0000ff', sp = '$cyan', fmt = 'underline,italic'},
@@ -436,10 +375,6 @@ nnoremap <C-S-p> diw"0P
 
 nnoremap <Space>vs  :vsplit<CR>
 nnoremap <Space>hs  :split<CR>
-
-nnoremap <Space>tl  :vs<CR>:TweetVimHomeTimeline<CR>
-nnoremap <Space>tm  :vs<CR>:TweetVimMentions<CR>
-nnoremap <Space>ts  :TweetVimSay<CR>
 
 inoremap <C-f> <C-x><C-o>
 
@@ -578,10 +513,10 @@ nnoremap <Leader>k[ i\left[<Space>\right]<Esc>F<Space>
 nnoremap <Leader>kred i<font color="MediumVioletRed"> </font><Esc>F<Space>
 
 nnoremap <Leader>ka i\alpha<Esc>
-nnoremap <Leader>kb i\bata<Esc>
+nnoremap <Leader>kb i\beta<Esc>
 nnoremap <Leader>kc i\gamma<Esc>
 nnoremap <Leader>kd i\delta<Esc>
-nnoremap <Leader>kl i\mu<Esc>
+nnoremap <Leader>km i\mu<Esc>
 nnoremap <Leader>kl i\lambda<Esc>
 
 nnoremap <Leader>kC i\Gamma<Esc>


### PR DESCRIPTION
## 概要
.vimrc の未使用プラグイン削除・競合プラグインの整理・バグ修正・起動時クラッシュの解消を行った。

## 関連Issue
なし

## 変更内容
- [x] バグ修正
- [x] リファクタリング

## 修正詳細

### プラグイン削除（未使用）
- `psf/black` — `!black %` の外部コマンド直呼びで動いており、プラグイン本体は使っていなかった
- `preservim/nerdtree` — nvim-tree に一本化済みのため削除
- `ctrlpvim/ctrlp.vim` — fzf / telescope を使用中のため削除
- TweetVim キーマッピング 3 件 — プラグインが存在しないまま残っていた

### プラグイン削除（coc.nvim と競合）
- `nvim-cmp` / `cmp-nvim-lsp` / `cmp-buffer` / `cmp-path` / `cmp-cmdline` / `LuaSnip` / `cmp_luasnip` / `nvim-lspconfig` および lua 設定ブロックを削除
- coc.nvim が rust / python / ts など全言語の LSP と補完を担当しているため一本化

### バグ修正
- `##8F917F` → `#8F917F`（onedark コメント色のダブルハッシュ）
- `\bata` → `\beta`（katex スニペットのタイポ）
- `<Leader>kl` の重複定義を解消（`\mu` 側を `<Leader>km` に変更）
- `shiftwidth=4` / `hlsearch` の重複 set を削除

### その他
- `markdown-preview.nvim` のインストールコマンドを `mkdp#util#install()` に更新
- すべての `require()` を `pcall` でガードし、プラグイン未インストール時の起動クラッシュを防止

## レビューのポイント
coc.nvim と nvim-cmp の共存を解消し coc.nvim に統一。coc がすでに `coc-pyright` / `coc-rust-analyzer` / `coc-tsserver` 等を管理しているため、nvim-lspconfig 側は不要と判断した。

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [x] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した