### PR TITLE
fix: git worktree remove のパス指定を修正

### DIFF
--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -237,7 +237,7 @@ gwr() {
     fi
 
     local folder="$1"
-    git worktree remove "../${folder}"
+    git worktree remove "${folder}"
 }
 
 alias gwl='git worktree list --verbose'


### PR DESCRIPTION
## 概要
`gwr` 関数内の `git worktree remove` でパスに `../` が付いていたため、絶対パスや相対パス渡しで失敗していたのを修正。

## 関連Issue
なし

## 変更内容
- [x] バグ修正

## 修正詳細
- `.zsh_aliases` の `gwr()` 関数: `git worktree remove "../${folder}"` → `git worktree remove "${folder}"`
- 呼び出し元から渡す `folder` がすでに正しいパスのため `../` の付加は不要だった

## チェックリスト
- [x] 自分のコードの自己レビューを完了した
- [x] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した