### PR TITLE
fix: PS1 prompt to shorten all path components except the last one

### DIFF
--- a/.zshrc.d/60-prompt.zsh
+++ b/.zshrc.d/60-prompt.zsh
@@ -24,11 +24,7 @@ function short_pwd {
   # Use zsh-native array slicing (all but the last element).
   for part in "${path_parts[1,-2]}"; do
     if [[ -n "$part" ]]; then
-      if [[ -z "$shortened_path" ]]; then
-        shortened_path+="/$part"
-      else
-        shortened_path+="/${part:0:3}"
-      fi
+      shortened_path+="/${part:0:3}"
     fi
   done
 


### PR DESCRIPTION
## 概要
PS1 プロンプトのパス表示ロジックを修正しました。現在のディレクトリパスの最初のパーツが短縮されない問題を解決し、最後のパーツ以外のすべてのパーツを3文字で短縮します。

## 変更内容
- [x] バグ修正

## 修正詳細
- `short_pwd` 関数のループ内で最初のパーツをフルで表示していた条件分岐を削除
- すべてのパーツ（最後を除く）に `${part:0:3}` を適用して統一的に3文字で短縮
- 結果として `~/AAAAAA/BBBBBB/CCCCCC/` が `~/AAA/BBB/CCCCCC` と正しく表示されるように修正

## チェックリスト
- [x] 自分のコードの自己レビューを完了した