### PR TITLE
fix: remove quotes from array slicing in short_pwd to properly iterate path components

### DIFF
--- a/.zshrc.d/60-prompt.zsh
+++ b/.zshrc.d/60-prompt.zsh
@@ -22,7 +22,7 @@ function short_pwd {
   last_part=${path_parts[-1]}
 
   # Use zsh-native array slicing (all but the last element).
-  for part in "${path_parts[1,-2]}"; do
+  for part in ${path_parts[1,-2]}; do
     if [[ -n "$part" ]]; then
       shortened_path+="/${part:0:3}"
     fi


### PR DESCRIPTION
## 概要
`short_pwd` 関数の配列スライスが引用符で囲まれていた問題を修正しました。これにより、ループが複数のパス要素を正しく反復処理するようになり、すべてのディレクトリを3文字で短縮できます。

## 変更内容
- [x] バグ修正

## 修正詳細
- `for part in "${path_parts[1,-2]}";` から引用符を削除して `for part in ${path_parts[1,-2]};` に変更
- 配列スライスが複数要素として正しく展開されるようになった
- 例：`~/src/github.com/GVATECH-AI` が `~/src/git/GVATECH-AI` と正しく表示される

## チェックリスト
- [x] 自分のコードの自己レビューを完了した