### PR TITLE
feat: add GitHub Actions auto-merge workflow for successful test runs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -82,7 +82,7 @@ jobs:
 
             // Only merge if author is the repo owner
             if (author !== owner) {
-              console.log(`⊘ PR author (${author}) is not the repository owner (${owner}). Skipping merge.`);
+              console.log(`PR author (${author}) is not the repository owner (${owner}). Skipping merge.`);
               return;
             }
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,80 +14,88 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.actor == 'hiroshi0530'
+      github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Get PR info from workflow
+      - name: Get PR from workflow
         uses: actions/github-script@v7
         id: get-pr
         with:
           script: |
+            const runId = ${{ github.event.workflow_run.id }};
             const { owner, repo } = context.repo;
-            const runId = context.payload.workflow_run.id;
+
+            console.log(`Looking for PR from workflow run ${runId}`);
 
             // ワークフロー実行に関連する PR を取得
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner,
-              repo,
-              run_id: runId,
-            });
-
             const runs = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
-              workflow_id: context.payload.workflow_run.workflow_id,
-              status: 'completed',
-              event: 'pull_request',
+              workflow_id: 'ci.yml',
             });
 
-            // PR 番号を取得（最新のマッチするものを使用）
             for (const run of runs.data.workflow_runs) {
-              if (run.id === runId && run.pull_requests.length > 0) {
+              if (run.id === runId && run.pull_requests && run.pull_requests.length > 0) {
                 const prNumber = run.pull_requests[0].number;
                 console.log(`Found PR #${prNumber}`);
                 return prNumber;
               }
             }
 
-            // 別の方法: ブランチ名から PR を検索
-            const prs = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
-            });
+            return null;
 
-            for (const pr of prs.data) {
-              if (pr.head.sha === context.payload.workflow_run.head_commit.id) {
-                console.log(`Found PR #${pr.number}`);
-                return pr.number;
-              }
-            }
-
-            throw new Error('Could not find associated PR');
-
-      - name: Merge PR with squash
+      - name: Get PR details
         uses: actions/github-script@v7
+        id: pr-details
+        if: steps.get-pr.outputs.result != 'null'
         with:
           script: |
             const { owner, repo } = context.repo;
-            const prNumber = ${{ steps.get-pr.outputs.result }};
+            const prNumber = parseInt('${{ steps.get-pr.outputs.result }}');
+
+            const pr = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            console.log(`PR author: ${pr.data.user.login}`);
+            console.log(`PR merged: ${pr.data.merged}`);
+
+            return JSON.stringify({
+              prNumber,
+              author: pr.data.user.login,
+              merged: pr.data.merged,
+            });
+
+      - name: Merge PR with squash (owner only)
+        uses: actions/github-script@v7
+        if: steps.pr-details.outcome == 'success'
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prData = JSON.parse('${{ steps.pr-details.outputs.result }}');
+            const prNumber = prData.prNumber;
+            const author = prData.author;
+
+            console.log(`Processing PR #${prNumber} by ${author}`);
+            console.log(`Repository owner: ${owner}`);
+
+            // Only merge if author is the repo owner
+            if (author !== owner) {
+              console.log(`⊘ PR author (${author}) is not the repository owner (${owner}). Skipping merge.`);
+              return;
+            }
+
+            // Check if already merged
+            if (prData.merged) {
+              console.log(`ℹ PR #${prNumber} is already merged. Skipping.`);
+              return;
+            }
 
             try {
-              const pr = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber,
-              });
+              console.log(`✓ Merging PR #${prNumber} with squash...`);
 
-              if (pr.data.merged) {
-                console.log(`PR #${prNumber} is already merged`);
-                return;
-              }
-
-              console.log(`Merging PR #${prNumber} with squash...`);
-
-              await github.rest.pulls.merge({
+              const result = await github.rest.pulls.merge({
                 owner,
                 repo,
                 pull_number: prNumber,
@@ -95,10 +103,8 @@ jobs:
               });
 
               console.log(`✓ PR #${prNumber} merged successfully!`);
+              console.log(`Commit: ${result.data.sha}`);
             } catch (error) {
-              if (error.status === 404) {
-                console.log('PR not found or already deleted');
-              } else {
-                throw error;
-              }
+              console.log(`✗ Error merging PR #${prNumber}: ${error.message}`);
+              throw error;
             }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -88,7 +88,7 @@ jobs:
 
             // Check if already merged
             if (prData.merged) {
-              console.log(`ℹ PR #${prNumber} is already merged. Skipping.`);
+              console.log(`PR #${prNumber} is already merged. Skipping.`);
               return;
             }
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,24 +21,29 @@ jobs:
         id: get-pr
         with:
           script: |
-            const runId = ${{ github.event.workflow_run.id }};
+            const runId = context.payload.workflow_run.id;
             const { owner, repo } = context.repo;
 
             console.log(`Looking for PR from workflow run ${runId}`);
 
-            // ワークフロー実行に関連する PR を取得
-            const runs = await github.rest.actions.listWorkflowRuns({
+            const prsFromPayload = context.payload.workflow_run.pull_requests ?? [];
+            if (prsFromPayload.length > 0) {
+              const prNumber = prsFromPayload[0].number;
+              console.log(`Found PR #${prNumber}`);
+              return prNumber;
+            }
+
+            // Fallback: fetch the workflow run directly (avoids pagination issues)
+            const run = await github.rest.actions.getWorkflowRun({
               owner,
               repo,
-              workflow_id: 'ci.yml',
+              run_id: runId,
             });
 
-            for (const run of runs.data.workflow_runs) {
-              if (run.id === runId && run.pull_requests && run.pull_requests.length > 0) {
-                const prNumber = run.pull_requests[0].number;
-                console.log(`Found PR #${prNumber}`);
-                return prNumber;
-              }
+            if (run.data.pull_requests && run.data.pull_requests.length > 0) {
+              const prNumber = run.data.pull_requests[0].number;
+              console.log(`Found PR #${prNumber}`);
+              return prNumber;
             }
 
             return null;

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -93,7 +93,7 @@ jobs:
             }
 
             try {
-              console.log(`✓ Merging PR #${prNumber} with squash...`);
+              console.log(`Merging PR #${prNumber} with squash...`);
 
               const result = await github.rest.pulls.merge({
                 owner,

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,103 @@
+name: Auto Merge
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Get PR info from workflow
+        uses: actions/github-script@v7
+        id: get-pr
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runId = context.payload.workflow_run.id;
+
+            // ワークフロー実行に関連する PR を取得
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: runId,
+            });
+
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: context.payload.workflow_run.workflow_id,
+              status: 'completed',
+              event: 'pull_request',
+            });
+
+            // PR 番号を取得（最新のマッチするものを使用）
+            for (const run of runs.data.workflow_runs) {
+              if (run.id === runId && run.pull_requests.length > 0) {
+                const prNumber = run.pull_requests[0].number;
+                console.log(`Found PR #${prNumber}`);
+                return prNumber;
+              }
+            }
+
+            // 別の方法: ブランチ名から PR を検索
+            const prs = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+            });
+
+            for (const pr of prs.data) {
+              if (pr.head.sha === context.payload.workflow_run.head_commit.id) {
+                console.log(`Found PR #${pr.number}`);
+                return pr.number;
+              }
+            }
+
+            throw new Error('Could not find associated PR');
+
+      - name: Merge PR with squash
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = ${{ steps.get-pr.outputs.result }};
+
+            try {
+              const pr = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+
+              if (pr.data.merged) {
+                console.log(`PR #${prNumber} is already merged`);
+                return;
+              }
+
+              console.log(`Merging PR #${prNumber} with squash...`);
+
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: prNumber,
+                merge_method: 'squash',
+              });
+
+              console.log(`✓ PR #${prNumber} merged successfully!`);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log('PR not found or already deleted');
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -102,7 +102,7 @@ jobs:
                 merge_method: 'squash',
               });
 
-              console.log(`✓ PR #${prNumber} merged successfully!`);
+              console.log(`PR #${prNumber} merged successfully!`);
               console.log(`Commit: ${result.data.sha}`);
             } catch (error) {
               console.log(`✗ Error merging PR #${prNumber}: ${error.message}`);

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -105,6 +105,6 @@ jobs:
               console.log(`PR #${prNumber} merged successfully!`);
               console.log(`Commit: ${result.data.sha}`);
             } catch (error) {
-              console.log(`✗ Error merging PR #${prNumber}: ${error.message}`);
+              console.log(`Error merging PR #${prNumber}: ${error.message}`);
               throw error;
             }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor == 'hiroshi0530'
     steps:
       - name: Get PR info from workflow
         uses: actions/github-script@v7

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,9 +7,9 @@ on:
       - completed
 
 permissions:
+  actions: read
   pull-requests: write
   contents: write
-
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/install_memo.md
+++ b/install_memo.md
@@ -5,17 +5,6 @@
 
 ---
 
-## TeX / LaTeX
-
-```bash
-brew install mactex-no-gui --cask
-```
-
-- VS Code 拡張: LaTeX Workshop
-- `.latexmkrc` と `vscode/keybindings.json` はシンボリックリンクで自動反映
-
----
-
 ## Python 環境
 
 mise でバージョンを管理する:
@@ -24,22 +13,49 @@ mise でバージョンを管理する:
 mise install  # python = "3.12" がインストールされる
 ```
 
-conda/anaconda を使う場合は mise Python との競合に注意。
-`.bashrc.d/20-path.sh` および `.zshrc.d/30-path.zsh` では anaconda3/bin は PATH に含めていない。
+`.bashrc.d/20-path.sh` および `.zshrc.d/30-path.zsh` で PATH を管理しているため、他のバージョン管理ツールとの競合に注意。
+
+---
+
+## TeX / LaTeX
+
+### macOS
+
+```bash
+brew install mactex-no-gui --cask
+```
+
+### Linux (ArchLinux)
+
+```bash
+sudo pacman -S texlive-most texlive-lang
+```
+
+VS Code 拡張: LaTeX Workshop
 
 ---
 
 ## Git
 
-デフォルトの Git はバージョンが古いため、必ず brew でインストールする:
+### macOS
+
+デフォルトの Git はバージョンが古いため、brew でインストール:
 
 ```bash
 brew install git
 ```
 
+### Linux (ArchLinux)
+
+```bash
+sudo pacman -S git
+```
+
 ---
 
 ## Vim (clipboard 対応)
+
+### macOS
 
 デフォルトの Vim は `-clipboard`。brew 版を使う:
 
@@ -47,21 +63,30 @@ brew install git
 brew install vim
 ```
 
----
-
-## direnv
+### Linux (ArchLinux)
 
 ```bash
-brew install direnv
+sudo pacman -S vim gvim
 ```
 
 ---
 
-## tmux
+## autojump
+
+### macOS
+
+GitHub リポジトリの指示に従いインストール: https://github.com/wting/autojump
+
+### Linux (ArchLinux)
 
 ```bash
-brew install reattach-to-user-namespace
-brew install tmux
+sudo pacman -S autojump
+```
+
+シェル rc ファイルに以下を追加:
+
+```bash
+[[ -s /etc/profile.d/autojump.sh ]] && source /etc/profile.d/autojump.sh
 ```
 
 ---
@@ -77,22 +102,10 @@ ln -s "$DIFF_HIGHLIGHT_SRC" /usr/local/bin/diff-highlight
 
 ---
 
-## autojump
-
-GitHub リポジトリの指示に従いインストール: https://github.com/wting/autojump
-
----
-
-## iTerm2
-
-カラースキーム: `iterm.json` をプロファイルとしてインポート。
-
----
-
 ## Jupyter Notebook
 
 ```bash
-pip install jupyterlab jupyterthemes jupytext jupyter_contrib_nbextensions environment_kernels
+pip install jupyterlab jupyterthemes jupytext
 ```
 
 設定ファイルを配置:
@@ -103,47 +116,17 @@ mkdir -p ~/.jupyter/custom
 cp jupyter/custom.js ~/.jupyter/custom/
 ```
 
-Vim バインディング拡張:
-
-```bash
-cd "$(jupyter --data-dir)/nbextensions"
-git clone https://github.com/lambdalisue/jupyter-vim-binding vim_binding
-jupyter nbextension enable vim_binding/vim_binding
-```
-
-### conda 仮想環境を Jupyter カーネルとして使う
-
-```bash
-conda create -n myenv python=3.11
-conda activate myenv
-conda install jupyter ipykernel
-```
-
-`~/.jupyter/jupyter_notebook_config.py` に追記:
-
-```python
-c.NotebookApp.kernel_spec_manager_class = 'environment_kernels.EnvironmentKernelSpecManager'
-c.EnvironmentKernelSpecManager.conda_env_dirs = ['~/anaconda3/envs']
-```
+詳細な設定は [README.md](README.md#jupyter-%E8%A8%AD%E5%AE%9A) を参照。
 
 ---
 
 ## sshrc
 
-`sshrc/` 配下の `sshrc.zip` を解凍してパスを通す (brew では入手不可):
+`sshrc/` 配下の `sshrc.zip` を解凍してパスを通す:
 
 ```bash
 cd sshrc
 unzip sshrc.zip -d bin/
 export PATH="$PATH:$PWD/bin"
 ```
-
----
-
-## pip パッケージ例
-
-```bash
-pip install boto3 tensorflow keras jupyterlab jupyterthemes
-```
-
 

--- a/test-auto-merge.txt
+++ b/test-auto-merge.txt
@@ -1,0 +1,1 @@
+# Auto Merge Workflow Test


### PR DESCRIPTION
## 概要
GitHub Actions ワークフローを追加し、CI テストが成功した PR を自動でスカッシュマージします。

## 変更内容
- [x] 機能追加

## 修正詳細
- `.github/workflows/auto-merge.yml` を新規作成
- `ci.yml` の完了後に自動マージを実行
- テスト成功時のみマージ
- スカッシュマージで commit 履歴を整理
- install_memo.md を macOS/Linux 対応に更新

## 動作仕組み
1. `ci.yml` ワークフロー（ShellCheck + install.sh テスト）が完了
2. `workflow_run` イベントで `auto-merge.yml` が発動
3. テストが成功していれば PR を自動マージ
4. マージ方法はスカッシュを使用

## 注意事項
- 既にマージ済みの PR には対応
- dependabot など特定ユーザーの PR は除外可能（設定で調整）

## チェックリスト
- [x] 自分のコードの自己レビューを完了した