### PR TITLE
feat: シェル環境の強化 (starship / atuin / sheldon / モダン CLI ツール)

### DIFF
--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -1,0 +1,33 @@
+# atuin configuration
+# https://docs.atuin.sh/configuration/config/
+
+# データベースの保存先
+db_path = "~/.local/share/atuin/history.db"
+
+# 同期を使わない場合は local のみ
+# sync_address = "https://api.atuin.sh"
+# auto_sync = true
+
+# 検索のデフォルトモード: prefix / fulltext / fuzzy / skim
+search_mode = "fuzzy"
+
+# フィルタリングのデフォルトモード: global / host / session / directory
+filter_mode = "global"
+
+# Ctrl-R を atuin に割り当てる
+# false にすると既存のキーバインドを変更しない
+# keymap_mode = "auto"
+
+# 表示する履歴の最大件数
+history_limit = 100000
+
+# 同一コマンドの重複を除去する
+unique = true
+
+# 終了コードが 0 以外のコマンドを保存する
+store_failed = true
+
+# 短いコマンドを保存しない (1文字以下)
+history_filter = [
+  "^\\s*$",
+]

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -27,6 +27,7 @@ fd       = "latest"
 delta    = "latest"
 lazygit  = "latest"
 zoxide   = "latest"
+ripgrep  = "latest"
 
 [env]
 # GOPATH: go install したバイナリを ~/go/bin に置く

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -16,6 +16,17 @@ kubectl = "latest"
 neovim  = "latest"
 tmux    = "latest"
 copilot = "latest"
+# shell enhancements
+sheldon  = "latest"
+starship = "latest"
+atuin    = "latest"
+# modern cli tools
+bat      = "latest"
+eza      = "latest"
+fd       = "latest"
+delta    = "latest"
+lazygit  = "latest"
+zoxide   = "latest"
 
 [env]
 # GOPATH: go install したバイナリを ~/go/bin に置く

--- a/.config/sheldon/plugins.toml
+++ b/.config/sheldon/plugins.toml
@@ -1,0 +1,22 @@
+# sheldon plugin configuration
+# https://sheldon.cli.rs/Configuration.html
+#
+# After install: sheldon lock
+# To update:    sheldon lock --update
+
+shell = "zsh"
+
+[plugins.zsh-autosuggestions]
+github = "zsh-users/zsh-autosuggestions"
+use = ["zsh-autosuggestions.zsh"]
+
+[plugins.zsh-syntax-highlighting]
+github = "zsh-users/zsh-syntax-highlighting"
+use = ["zsh-syntax-highlighting.zsh"]
+
+[plugins.zsh-history-substring-search]
+github = "zsh-users/zsh-history-substring-search"
+use = ["zsh-history-substring-search.zsh"]
+
+[templates]
+defer = "{% for file in files %}zsh-defer source \"{{ file }}\"\n{% endfor %}"

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,0 +1,87 @@
+# Starship prompt configuration
+# https://starship.rs/config/
+#
+# Preset: no-nerd-font (no special fonts required)
+# To use Nerd Font icons, comment out the format lines and use:
+#   starship preset nerd-font-symbols -o ~/.config/starship.toml
+
+format = """
+$username\
+$hostname\
+$directory\
+$git_branch\
+$git_state\
+$git_status\
+$cmd_duration\
+$line_break\
+$python\
+$node\
+$golang\
+$rust\
+$character"""
+
+[directory]
+truncation_length = 4
+truncate_to_repo = true
+style = "bold cyan"
+
+[git_branch]
+format = "[$symbol$branch]($style) "
+symbol = "* "
+style = "bold green"
+
+[git_status]
+format = '([\[$all_status$ahead_behind\]]($style) )'
+style = "bold red"
+conflicted = "="
+ahead = ">"
+behind = "<"
+diverged = "<>"
+untracked = "?"
+stashed = "$"
+modified = "!"
+staged = "+"
+renamed = "r"
+deleted = "x"
+
+[cmd_duration]
+min_time = 2_000
+format = "[$duration]($style) "
+style = "bold yellow"
+
+[python]
+format = '[$symbol$version]($style) '
+symbol = "py "
+style = "bold blue"
+detect_files = ["pyproject.toml", "requirements.txt", ".python-version", "Pipfile"]
+
+[nodejs]
+format = '[$symbol$version]($style) '
+symbol = "node "
+style = "bold green"
+detect_files = ["package.json", ".node-version", ".nvmrc"]
+
+[golang]
+format = '[$symbol$version]($style) '
+symbol = "go "
+style = "bold cyan"
+detect_files = ["go.mod", "go.sum"]
+
+[rust]
+format = '[$symbol$version]($style) '
+symbol = "rs "
+style = "bold red"
+detect_files = ["Cargo.toml"]
+
+[character]
+success_symbol = "[>](bold green)"
+error_symbol = "[>](bold red)"
+vicmd_symbol = "[<](bold yellow)"
+
+[username]
+show_always = false
+
+[hostname]
+ssh_only = true
+format = "[$hostname]($style) "
+style = "bold dimmed green"

--- a/.gitconfig.local
+++ b/.gitconfig.local
@@ -46,6 +46,17 @@
   show = diff-highlight | less
   diff = diff-highlight | less
 
+# delta (better diff pager): uncommment below to enable
+# delta is installed via mise. After `mise install`, uncomment:
+# [core]
+#   pager = delta
+# [interactive]
+#   diffFilter = delta --color-only
+# [delta]
+#   navigate = true
+#   light = false
+#   side-by-side = false
+
 [credential "https://github.com"]
   helper = !/usr/bin/gh auth git-credential
 

--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -59,10 +59,32 @@ alias vssh='v ~/.ssh/config'
 alias vaws='v ~/.aws/credentials'
 alias vgit='nvim ~/.gitconfig'
 
+# bat (better cat)
+if command -v bat >/dev/null 2>&1; then
+  alias cat='bat --paging=never'
+  alias catp='bat'
+fi
+
+# lazygit
+if command -v lazygit >/dev/null 2>&1; then
+  alias lg='lazygit'
+fi
+
 # list
-alias ll='ls -alGh --color'
-alias la='ll -Ah'
-alias l='ls -CFh'
+# eza (modern ls) を優先し、未インストールの場合は ls にフォールバック
+if command -v eza >/dev/null 2>&1; then
+  alias ll='eza -alh --git --icons=never'
+  alias la='eza -alh --git --icons=never -a'
+  alias l='eza -F --icons=never'
+  alias tree='eza --tree --icons=never'
+  alias ftree='eza --tree --icons=never -a'
+else
+  alias ll='ls -alGh --color'
+  alias la='ll -Ah'
+  alias l='ls -CFh'
+  alias tree='tree -NF'
+  alias ftree='tree -afipugsDf'
+fi
 alias df='df -H -m'
 alias du='du -H -m'
 alias h='history'

--- a/.zshrc.d/20-history.zsh
+++ b/.zshrc.d/20-history.zsh
@@ -2,3 +2,10 @@
 export HISTFILE="$HOME/.zsh_history"
 export HISTSIZE=100000
 export SAVEHIST=100000
+
+# atuin: enhanced shell history
+# https://docs.atuin.sh/
+# Ctrl-R で fuzzy 検索、通常の上下矢印はそのまま使える
+if command -v atuin >/dev/null 2>&1; then
+  eval "$(atuin init zsh --disable-up-arrow)"
+fi

--- a/.zshrc.d/60-prompt.zsh
+++ b/.zshrc.d/60-prompt.zsh
@@ -1,34 +1,43 @@
 # shellcheck shell=zsh
-function short_pwd {
-  local full_path="$PWD"
-  local shortened_path=""
-  local part
-  local last_part
+# Starship prompt
+# https://starship.rs/
+#
+# Fallback: minimal PS1 if starship is not installed
 
-  if [[ $full_path == "$HOME" || $full_path == "$HOME"/* ]]; then
-    shortened_path="~"
-    full_path=${full_path#"$HOME"}
-  fi
+if command -v starship >/dev/null 2>&1; then
+  eval "$(starship init zsh)"
+else
+  # fallback: short_pwd prompt
+  function short_pwd {
+    local full_path="$PWD"
+    local shortened_path=""
+    local part
+    local last_part
 
-  # shellcheck disable=SC2296,SC2206
-  local path_parts=(${(s:/:)full_path})
-
-  if [[ ${#path_parts[@]} -le 0 ]]; then
-    [[ -n "$full_path" ]] && shortened_path+="$full_path"
-    echo "$shortened_path"
-    return
-  fi
-
-  last_part=${path_parts[-1]}
-
-  # Use zsh-native array slicing (all but the last element).
-  for part in ${path_parts[1,-2]}; do
-    if [[ -n "$part" ]]; then
-      shortened_path+="/${part:0:3}"
+    if [[ $full_path == "$HOME" || $full_path == "$HOME"/* ]]; then
+      shortened_path="~"
+      full_path=${full_path#"$HOME"}
     fi
-  done
 
-  shortened_path+="/$last_part"
-  echo "$shortened_path"
-}
-export PS1='$(short_pwd) $ '
+    # shellcheck disable=SC2296,SC2206
+    local path_parts=(${(s:/:)full_path})
+
+    if [[ ${#path_parts[@]} -le 0 ]]; then
+      [[ -n "$full_path" ]] && shortened_path+="$full_path"
+      echo "$shortened_path"
+      return
+    fi
+
+    last_part=${path_parts[-1]}
+
+    for part in ${path_parts[1,-2]}; do
+      if [[ -n "$part" ]]; then
+        shortened_path+="/${part:0:3}"
+      fi
+    done
+
+    shortened_path+="/$last_part"
+    echo "$shortened_path"
+  }
+  export PS1='$(short_pwd) $ '
+fi

--- a/.zshrc.d/70-tools.zsh
+++ b/.zshrc.d/70-tools.zsh
@@ -14,10 +14,27 @@ if [[ -f /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]]; then
 elif [[ -f /usr/share/fzf/key-bindings.zsh ]]; then
   source /usr/share/fzf/key-bindings.zsh
 fi
-export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -200'"
+# eza を使う場合はツリー表示に eza を利用する
+if command -v eza >/dev/null 2>&1; then
+  export FZF_ALT_C_OPTS="--preview 'eza --tree --icons=never {} | head -200'"
+else
+  export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -200'"
+fi
 
-# autojump
-[[ -s "$HOME/.autojump/etc/profile.d/autojump.sh" ]] && source "$HOME/.autojump/etc/profile.d/autojump.sh"
+# zoxide (modern autojump)
+# z <dir> で移動、zi で fzf 対話選択
+if command -v zoxide >/dev/null 2>&1; then
+  eval "$(zoxide init zsh)"
+else
+  # fallback: autojump
+  [[ -s "$HOME/.autojump/etc/profile.d/autojump.sh" ]] && source "$HOME/.autojump/etc/profile.d/autojump.sh"
+fi
+
+# delta: git diff pager
+# .gitconfig の [core] pager に delta を使うためのヘルパー設定
+if command -v delta >/dev/null 2>&1; then
+  export GIT_PAGER='delta'
+fi
 
 # kubectl completion
 command -v kubectl >/dev/null 2>&1 && source <(kubectl completion zsh)

--- a/.zshrc.d/80-plugins.zsh
+++ b/.zshrc.d/80-plugins.zsh
@@ -1,0 +1,18 @@
+# shellcheck shell=zsh
+# zsh plugin management via sheldon
+# https://sheldon.cli.rs/
+
+if command -v sheldon >/dev/null 2>&1; then
+  eval "$(sheldon source)"
+
+  # zsh-history-substring-search: 上下矢印で部分一致履歴検索
+  bindkey '^[[A' history-substring-search-up
+  bindkey '^[[B' history-substring-search-down
+  bindkey -M vicmd 'k' history-substring-search-up
+  bindkey -M vicmd 'j' history-substring-search-down
+
+  # zsh-autosuggestions: Tab で補完候補を確定
+  ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=244'
+  ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+  bindkey '^ ' autosuggest-accept
+fi

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,29 @@ run mkdir -p "$HOME/.config/mise"
 symlink "$SCRIPT_DIR/.config/mise/config.toml" "$HOME/.config/mise/config.toml"
 
 # ---------------------------------------------------------------------------
+# sheldon: zsh plugin manager config
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Linking sheldon config"
+run mkdir -p "$HOME/.config/sheldon"
+symlink "$SCRIPT_DIR/.config/sheldon/plugins.toml" "$HOME/.config/sheldon/plugins.toml"
+
+# ---------------------------------------------------------------------------
+# starship: prompt config
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Linking starship config"
+symlink "$SCRIPT_DIR/.config/starship.toml" "$HOME/.config/starship.toml"
+
+# ---------------------------------------------------------------------------
+# atuin: shell history config
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Linking atuin config"
+run mkdir -p "$HOME/.config/atuin"
+symlink "$SCRIPT_DIR/.config/atuin/config.toml" "$HOME/.config/atuin/config.toml"
+
+# ---------------------------------------------------------------------------
 # Git config
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要

シェルの生産性向上を目的に、プロンプト・履歴・補完・モダン CLI ツールを追加する。

## 変更内容

- [x] 機能追加

## 修正詳細

### zsh プラグイン管理 (sheldon)
- `.zshrc.d/80-plugins.zsh` を新規追加
- `.config/sheldon/plugins.toml` を新規追加
  - zsh-autosuggestions: 履歴からコマンドをサジェスト (Ctrl+Space で確定)
  - zsh-syntax-highlighting: タイポをリアルタイム検出
  - zsh-history-substring-search: 上下矢印で部分一致履歴検索

### Starship プロンプト
- `.zshrc.d/60-prompt.zsh` を Starship 対応に更新
  - starship 未インストール時は従来の short_pwd にフォールバック
- `.config/starship.toml` を新規追加
  - git ブランチ・状態、Python/Node/Go/Rust バージョン、コマンド実行時間を表示

### atuin 履歴強化
- `.zshrc.d/20-history.zsh` に atuin init を追加
  - Ctrl-R で fuzzy 検索、上矢印は通常の履歴移動のまま維持
- `.config/atuin/config.toml` を新規追加

### モダン CLI ツール
- `.config/mise/config.toml` に追加:
  - sheldon / starship / atuin
  - bat (cat 代替) / eza (ls 代替) / fd (find 代替)
  - delta (git diff 代替) / lazygit (git TUI) / zoxide (autojump 代替) / ripgrep
- `.zsh_aliases` を更新:
  - `ll` / `l` / `tree` を eza 対応に (未インストール時は ls にフォールバック)
  - `cat` を bat に、`lg` を lazygit に
- `.zshrc.d/70-tools.zsh` を更新:
  - zoxide init 追加 (未インストール時は autojump にフォールバック)
  - delta インストール時に GIT_PAGER を設定
- `.gitconfig.local` に delta 設定のコメントを追加 (有効化は任意)

### install.sh
- sheldon / starship / atuin の設定ファイルのシンボリックリンクを追加

## レビューのポイント

- 各ツールは `command -v` で存在確認してからフォールバックしているため、`mise install` 前でも既存の動作は壊れない
- delta は `.gitconfig.local` のコメントアウトを外すことで有効化できる設計にした

## チェックリスト

- [x] 自分のコードの自己レビューを完了した
- [x] 未インストール時のフォールバックを確認した
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した