### PR TITLE
chore: remove eza, confirm ripgrep in mise managed tools

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -21,7 +21,6 @@ sheldon  = "latest"
 atuin    = "latest"
 # modern cli tools
 bat      = "latest"
-eza      = "latest"
 fd       = "latest"
 delta    = "latest"
 lazygit  = "latest"

--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -71,20 +71,11 @@ if command -v lazygit >/dev/null 2>&1; then
 fi
 
 # list
-# eza (modern ls) を優先し、未インストールの場合は ls にフォールバック
-if command -v eza >/dev/null 2>&1; then
-  alias ll='eza -alh --git --icons=never'
-  alias la='eza -alh --git --icons=never -a'
-  alias l='eza -F --icons=never'
-  alias tree='eza --tree --icons=never'
-  alias ftree='eza --tree --icons=never -a'
-else
-  alias ll='ls -alGh --color'
-  alias la='ll -Ah'
-  alias l='ls -CFh'
-  alias tree='tree -NF'
-  alias ftree='tree -afipugsDf'
-fi
+alias ll='ls -alGh --color'
+alias la='ll -Ah'
+alias l='ls -CFh'
+alias tree='tree -NF'
+alias ftree='tree -afipugsDf'
 alias df='df -H -m'
 alias du='du -H -m'
 alias h='history'

--- a/.zshrc.d/70-tools.zsh
+++ b/.zshrc.d/70-tools.zsh
@@ -14,12 +14,7 @@ if [[ -f /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]]; then
 elif [[ -f /usr/share/fzf/key-bindings.zsh ]]; then
   source /usr/share/fzf/key-bindings.zsh
 fi
-# eza を使う場合はツリー表示に eza を利用する
-if command -v eza >/dev/null 2>&1; then
-  export FZF_ALT_C_OPTS="--preview 'eza --tree --icons=never {} | head -200'"
-else
-  export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -200'"
-fi
+export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -200'"
 
 # zoxide (modern autojump)
 # z <dir> で移動、zi で fzf 対話選択


### PR DESCRIPTION
- mise: remove eza (ripgrep was already managed)
- aliases: revert ll/la/l/tree/ftree to ls/tree (remove eza conditional)
- 70-tools.zsh: remove eza branch from FZF_ALT_C_OPTS

## 概要
<!-- このPRで行った変更の概要を記述してください -->

## 関連Issue
<!-- 関連するIssue番号を記載（例: Closes #123） -->
Closes #

## 変更内容
<!-- 箇条書きで具体的に記述してください -->
- [ ] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新

## 修正詳細
- 
- 

## スクリーンショット・デモ
<!-- 変更前・後が分かる画像やGIFを貼り付けてください -->
| Before | After |
| :--- | :--- |
| ![Before](URL) | ![After](URL) |

## レビューのポイント
<!-- 特に見てほしい箇所や、相談したい内容があれば記述してください -->

## チェックリスト
<!-- 自己レビューが完了したらチェックしてください -->
- [ ] 自分のコードの自己レビューを完了した
- [ ] 必要な箇所にコメントを入れた
- [ ] テストを追加した
- [ ] 新しい機能はドキュメントを更新した

