### PR TITLE
feat: add GitHub CLI extensions (gh-dash, gh-markdown-preview) to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -197,5 +197,28 @@ else
   echo "  [skip] mise not found. Install from https://mise.jdx.dev/getting-started.html"
 fi
 
+# ---------------------------------------------------------------------------
+# GitHub CLI extensions
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Installing GitHub CLI extensions"
+if command -v gh >/dev/null 2>&1; then
+  gh_extensions=(
+    "dlvhdr/gh-dash"             # PR/Issue dashboard
+    "yusukebe/gh-markdown-preview" # Markdown preview
+  )
+  for ext in "${gh_extensions[@]}"; do
+    ext_name="${ext##*/}"
+    if gh extension list 2>/dev/null | grep -q "$ext_name"; then
+      echo "  (already installed: $ext_name)"
+    else
+      echo "  installing: $ext"
+      run gh extension install "$ext"
+    fi
+  done
+else
+  echo "  [skip] gh not found. Install from https://cli.github.com/"
+fi
+
 echo ""
 echo "==> Done."


### PR DESCRIPTION
## 概要

`install.sh` に GitHub CLI 拡張のインストール処理を追加する。

## 追加する拡張

| 拡張 | 概要 |
|------|------|
| `dlvhdr/gh-dash` | PR/Issue ダッシュボード |
| `yusukebe/gh-markdown-preview` | Markdown プレビュー |

## 動作

- インストール済みの場合はスキップ（冪等性あり）
- `gh` コマンドが見つからない場合はスキップしてメッセージを表示