### PR TITLE
feat: integrate nvim config into dotfiles

### DIFF
--- a/.config/nvim/.gitignore
+++ b/.config/nvim/.gitignore
@@ -1,0 +1,5 @@
+# vim-plug のインストール先（PlugInstall で自動生成される）
+plugged/
+
+# Neovim パッケージマネージャ経由でインストールされるプラグイン
+pack/

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,14 @@ for script in "$SCRIPT_DIR/bin/"*; do
 done
 
 # ---------------------------------------------------------------------------
+# Neovim: link init.vim to .vimrc
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Linking nvim config"
+run mkdir -p "$HOME/.config/nvim"
+symlink "$SCRIPT_DIR/.vimrc" "$HOME/.config/nvim/init.vim"
+
+# ---------------------------------------------------------------------------
 # mise: global tool config
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要

既存の vim-plug 構成を dotfiles 管理に統合する。

## 変更内容

| ファイル | 内容 |
|---|---|
| `.config/nvim/.gitignore` | `plugged/`（vim-plug）と `pack/`（Copilot等）を git 除外 |
| `install.sh` | `~/.config/nvim/init.vim -> ~/dotfiles/.vimrc` の symlink を自動作成 |

## 新環境での再現手順

```bash
./install.sh          # init.vim symlink が作成される
nvim +PlugInstall     # vim-plug でプラグインを自動インストール
```

## 注意

- `plugged/` は vim-plug が自動生成するため git 管理不要
- `pack/github/start/copilot.vim` も git 管理不要（`Plug 'github/copilot.vim'` で自動インストール）