### PR TITLE
feat: add declarative OS package management to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,8 +96,10 @@ elif command -v apt-get >/dev/null 2>&1; then
   while IFS= read -r pkg; do
     if dpkg -s "$pkg" >/dev/null 2>&1; then
       echo "  (already installed: $pkg)"
-    else
+    elif apt-cache show "$pkg" >/dev/null 2>&1; then
       pkgs+=("$pkg")
+    else
+      echo "  [skip] package not available via apt: $pkg"
     fi
   done < <(_pkg_list_install "$pkg_file")
   if [[ ${#pkgs[@]} -gt 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ echo "==> Installing OS packages"
 _pkg_list_install() {
   local pkg_file="$1"
   # コメント行と空行を除いてパッケージ名のみ抽出
-  grep -v '^\s*#' "$pkg_file" | grep -v '^\s*$'
+  grep -Ev '^[[:space:]]*(#|$)' -- "$pkg_file"
 }
 
 if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,67 @@ symlink() {
 echo "==> Starting dotfiles install (dry-run: $DRY_RUN)"
 
 # ---------------------------------------------------------------------------
+# OS パッケージのインストール
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Installing OS packages"
+
+_pkg_list_install() {
+  local pkg_file="$1"
+  # コメント行と空行を除いてパッケージ名のみ抽出
+  grep -v '^\s*#' "$pkg_file" | grep -v '^\s*$'
+}
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
+  pkg_file="$SCRIPT_DIR/packages/brew.txt"
+  echo "  detected: macOS (Homebrew)"
+  while IFS= read -r pkg; do
+    if brew list "$pkg" >/dev/null 2>&1; then
+      echo "  (already installed: $pkg)"
+    else
+      echo "  installing: $pkg"
+      run brew install "$pkg"
+    fi
+  done < <(_pkg_list_install "$pkg_file")
+
+elif command -v pacman >/dev/null 2>&1; then
+  pkg_file="$SCRIPT_DIR/packages/pacman.txt"
+  echo "  detected: Arch Linux (pacman)"
+  pkgs=()
+  while IFS= read -r pkg; do
+    if pacman -Q "$pkg" >/dev/null 2>&1; then
+      echo "  (already installed: $pkg)"
+    else
+      pkgs+=("$pkg")
+    fi
+  done < <(_pkg_list_install "$pkg_file")
+  if [[ ${#pkgs[@]} -gt 0 ]]; then
+    echo "  installing: ${pkgs[*]}"
+    run sudo pacman -S --needed --noconfirm "${pkgs[@]}"
+  fi
+
+elif command -v apt-get >/dev/null 2>&1; then
+  pkg_file="$SCRIPT_DIR/packages/apt.txt"
+  echo "  detected: Debian/Ubuntu (apt)"
+  run sudo apt-get update -qq
+  pkgs=()
+  while IFS= read -r pkg; do
+    if dpkg -s "$pkg" >/dev/null 2>&1; then
+      echo "  (already installed: $pkg)"
+    else
+      pkgs+=("$pkg")
+    fi
+  done < <(_pkg_list_install "$pkg_file")
+  if [[ ${#pkgs[@]} -gt 0 ]]; then
+    echo "  installing: ${pkgs[*]}"
+    run sudo apt-get install -y "${pkgs[@]}"
+  fi
+
+else
+  echo "  [skip] no supported package manager found (pacman/apt/brew)"
+fi
+
+# ---------------------------------------------------------------------------
 # Dotfiles: symlink all hidden files/dirs (except .git, .DS_Store, .github, .codex, .config)
 # ---------------------------------------------------------------------------
 echo ""

--- a/packages/apt.txt
+++ b/packages/apt.txt
@@ -1,0 +1,21 @@
+# Ubuntu/Debian (apt) パッケージリスト
+# mise が管理するツールはここに含めない
+#
+# インストール: xargs apt-get install -y < packages/apt.txt
+
+# 基本開発ツール
+build-essential
+git
+curl
+wget
+unzip
+
+# GitHub CLI (apt リポジトリ追加が別途必要)
+gh
+
+# コンテナ
+docker.io
+
+# 開発補助ツール（mise 非管理）
+direnv
+fzf

--- a/packages/apt.txt
+++ b/packages/apt.txt
@@ -1,7 +1,7 @@
 # Ubuntu/Debian (apt) パッケージリスト
 # mise が管理するツールはここに含めない
 #
-# インストール: xargs apt-get install -y < packages/apt.txt
+# インストール: grep -Ev '^[[:space:]]*(#|$)' packages/apt.txt | xargs -r sudo apt-get install -y
 
 # 基本開発ツール
 build-essential

--- a/packages/brew.txt
+++ b/packages/brew.txt
@@ -1,0 +1,17 @@
+# macOS (Homebrew) パッケージリスト
+# mise が管理するツールはここに含めない
+#
+# インストール: brew install $(grep -v '^#' packages/brew.txt | grep -v '^$')
+
+# 基本ツール
+git
+curl
+wget
+
+# GitHub CLI
+gh
+
+# 開発補助ツール（mise 非管理）
+direnv
+ghq
+fzf

--- a/packages/pacman.txt
+++ b/packages/pacman.txt
@@ -1,0 +1,22 @@
+# Arch Linux (pacman) パッケージリスト
+# mise が管理するツール (neovim, tmux, bat, ripgrep 等) はここに含めない
+#
+# インストール: pacman -S --needed - < packages/pacman.txt
+
+# 基本開発ツール
+base-devel
+git
+curl
+wget
+unzip
+
+# GitHub CLI
+github-cli
+
+# コンテナ
+docker
+
+# 開発補助ツール（mise 非管理）
+direnv
+ghq
+fzf

--- a/packages/pacman.txt
+++ b/packages/pacman.txt
@@ -1,7 +1,7 @@
 # Arch Linux (pacman) パッケージリスト
 # mise が管理するツール (neovim, tmux, bat, ripgrep 等) はここに含めない
 #
-# インストール: pacman -S --needed - < packages/pacman.txt
+# インストール: grep -Ev '^[[:space:]]*(#|$)' packages/pacman.txt | sudo pacman -S --needed --noconfirm -
 
 # 基本開発ツール
 base-devel


### PR DESCRIPTION
## 概要

OS レベルのパッケージを宣言的に管理できるようにする。mise が管理するツール（neovim・tmux・bat 等）は含めず、OS 側でしか管理できないものを対象とする。

## 変更内容

### パッケージリスト (packages/)

| ファイル | 対象OS |
|---|---|
| `packages/pacman.txt` | Arch Linux |
| `packages/apt.txt` | Ubuntu / Debian |
| `packages/brew.txt` | macOS (Homebrew) |

### install.sh

OS を自動検出して対応するパッケージマネージャでインストール:
- インストール済みはスキップ（冪等）
- dry-run 対応（`-n` フラグ）
- 未対応 OS はスキップしてメッセージ表示

## パッケージ管理の方針

| 管理場所 | 対象 |
|---|---|
| `packages/*.txt` | docker・direnv・ghq・gh・base-devel など |
| `mise config.toml` | 開発ツール全般（neovim・tmux・bat 等） |