### PR TITLE
docs: rewrite README with current structure and install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ install.sh 実行後、初回のみ以下を実行:
 nvim +PlugInstall +qall
 ```
 
-`plugged/`（vim-plug）と `pack/`（copilot.vim 等）は `.gitignore` 対象のため自動生成される。
+`plugged/`（vim-plug）と `pack/`（Neovim 標準パッケージで導入したプラグイン）は `.gitignore` 対象のため自動生成される。
 
 **Nerd Font（WSL2 / Windows Terminal）**
 

--- a/README.md
+++ b/README.md
@@ -2,104 +2,175 @@
 
 個人の開発環境設定を一元管理するリポジトリです。
 
-## 構成
+## ディレクトリ構成
 
 ```
 .
-├── install.sh               # セットアップスクリプト
+├── install.sh               # セットアップスクリプト（symlink・パッケージ・ツール一括設定）
+├── packages/                # OS 別パッケージリスト（宣言的管理）
+│   ├── pacman.txt           #   Arch Linux
+│   ├── apt.txt              #   Ubuntu / Debian
+│   ├── brew.txt             #   macOS (brew install)
+│   └── brew-cask.txt        #   macOS (brew install --cask)
+├── bin/                     # 個人スクリプト（install.sh が ~/bin に symlink）
+│   └── tmux-sessionizer     #   ghq + fzf でプロジェクト選択 → tmux session 接続
+├── files/                   # テンプレート類（symlink 対象外）
+│   ├── .envrc.python.tpl    #   direnv テンプレート: Python
+│   ├── .envrc.node.tpl      #   direnv テンプレート: Node.js
+│   ├── .envrc.go.tpl        #   direnv テンプレート: Go
+│   └── .envrc.rust.tpl      #   direnv テンプレート: Rust
 ├── .bashrc                  # bash 設定 (.bashrc.d/ をロード)
 ├── .bashrc.d/               # bash モジュール設定
-│   ├── 00-env.sh
-│   ├── 10-history.sh
-│   ├── 20-path.sh
-│   ├── 30-terminal.sh
-│   ├── 40-less.sh
-│   ├── 50-completion.sh
-│   ├── 60-prompt.sh
-│   └── 70-tools.sh
 ├── .zshrc                   # zsh 設定 (.zshrc.d/ をロード)
 ├── .zshrc.d/                # zsh モジュール設定
-│   ├── 00-options.zsh
-│   ├── 10-env.zsh
-│   ├── 20-history.zsh
-│   ├── 30-path.zsh
-│   ├── 40-less.zsh
-│   ├── 50-completion.zsh
-│   ├── 60-prompt.zsh
-│   └── 70-tools.zsh
-├── .gitconfig.local         # Git 設定 (install.sh が ~/.gitconfig にコピー)
-├── .vimrc                   # Vim/Neovim 設定
+│   ├── 30-path.zsh          #   PATH 管理（重複排除）
+│   └── 70-tools.zsh         #   mise / fzf / zoxide / direnv / tmux-sessionizer
+├── .vimrc                   # Vim/Neovim 共通設定（~/.config/nvim/init.vim に symlink）
+├── .config/
+│   ├── nvim/
+│   │   ├── os/              #   OS 別 Neovim 設定
+│   │   │   ├── mac.vim      #     macOS: clipboard 設定
+│   │   │   ├── wsl.vim      #     WSL2: win32yank クリップボード設定
+│   │   │   └── linux.vim    #     Linux: 拡張用
+│   │   └── .gitignore       #   plugged/ pack/ を git 除外
+│   ├── mise/
+│   │   └── config.toml      #   mise 管理ツール一覧
+│   ├── sheldon/
+│   │   └── plugins.toml     #   zsh プラグインマネージャ設定
+│   └── atuin/
+│       └── config.toml      #   シェル履歴管理設定
+├── .gitconfig.local         # Git 設定（install.sh が ~/.gitconfig にコピー）
 ├── .tmux.conf               # tmux 設定
-├── .ideavimrc               # JetBrains IDE Vim エミュレーション設定
+├── .tigrc                   # tig 設定
 ├── .github/
 │   ├── copilot-instructions.md  # GitHub Copilot 指示書（全リポジトリで自動適用）
-│   ├── prompts/                 # Copilot カスタムプロンプト（手動呼び出し）
+│   ├── prompts/                 # Copilot カスタムプロンプト
 │   └── workflows/               # GitHub Actions
 ├── vscode/
 │   ├── settings.json        # VS Code 設定
 │   ├── keybindings.json     # VS Code キーバインド
 │   └── snippet/             # VS Code スニペット
-├── jupyter/
-│   ├── jupyter_notebook_config.py  # Jupyter 設定 (git管理用自動変換)
-│   ├── custom.js            # Jupyter Vim キーバインド拡張
-│   └── notebook.json        # Jupyter Notebook 設定
-├── msshrc/
-│   ├── connect.sh           # 複数ホストへの同時 SSH (tmux)
-│   └── connect_k.sh         # k1〜k4 ホストへの一括接続
-├── sshrc/                   # sshrc (リモート環境への設定持ち込み)
-└── .sshrc.d/                # sshrc で読み込まれる設定
+├── jupyter/                 # Jupyter Notebook 設定
+├── msshrc/                  # 複数ホスト同時 SSH（tmux）
+└── sshrc/                   # リモート環境への設定持ち込み
 ```
-
-## 必要なツール
-
-| ツール | 用途 | 必須 |
-|--------|------|:----:|
-| git | バージョン管理 | ✓ |
-| vim / neovim | エディタ | ✓ |
-| tmux | ターミナルマルチプレクサ | ✓ |
-| zsh または bash | シェル | ✓ |
-| direnv | ディレクトリ別環境変数 | |
-| fzf | ファジー検索 | |
-| autojump | ディレクトリジャンプ | |
-| mise | ランタイムバージョン管理 | |
-| pyenv | Python バージョン管理 | |
-| nvm | Node.js バージョン管理 | |
-| GitHub CLI (gh) | GitHub 認証・操作 | |
 
 ## セットアップ
 
 ```bash
-git clone https://github.com/<your-username>/dotfiles.git ~/dotfiles
+git clone https://github.com/hiroshi0530/dotfiles.git ~/dotfiles
 cd ~/dotfiles
-./install.sh
-```
-
-ドライランで変更内容を確認してから実行することを推奨します:
-
-```bash
-./install.sh -n   # dry run (何も変更しない)
+./install.sh -n   # dry run（何も変更しない）
 ./install.sh      # 実際にインストール
 ```
 
 ### install.sh の処理内容
 
-1. `.??*` にマッチする隠しファイル/ディレクトリを `$HOME` にシンボリックリンク
-   - `.git`, `.DS_Store`, `.github`, `.codex` は除外
-2. `.gitconfig.local` → `~/.gitconfig` にコピー
-3. VS Code 設定を自動リンク (`settings.json`, `keybindings.json`, スニペット)
-4. IPython Vim モードの有効化
-5. `~/swap` (Vim スワップファイル用) ディレクトリ作成
-6. `diff-highlight` のシンボリックリンク作成 (存在する場合)
+| ステップ | 内容 |
+|---|---|
+| OS パッケージ | `packages/*.txt` を参照し pacman / apt / brew で一括インストール |
+| dotfiles symlink | `.??*` の隠しファイル/ディレクトリを `$HOME` に symlink（`.git` `.github` `.codex` `.config` 除外） |
+| bin/ symlink | `bin/*` を `~/bin/` に symlink |
+| Neovim | `~/.config/nvim/init.vim -> .vimrc`、`~/.config/nvim/os -> .config/nvim/os` を symlink |
+| mise | `~/.config/mise/config.toml` を symlink |
+| sheldon | `~/.config/sheldon/plugins.toml` を symlink |
+| atuin | `~/.config/atuin/config.toml` を symlink |
+| VS Code | `settings.json` / `keybindings.json` / スニペット / Copilot プロンプトを symlink |
+| .gitconfig | `.gitconfig.local` を `~/.gitconfig` にコピー |
+| .github | `~/.github -> .github` を symlink（Copilot 指示書） |
+| GitHub CLI 拡張 | `gh-dash`（PR/Issue ダッシュボード）/ `gh-markdown-preview` をインストール |
+| mise install | `config.toml` に記載されたツールを一括インストール |
 
-## VS Code 拡張機能一覧の確認
+### インストール時の注意点
+
+**WSL2 環境**
+
+- `packages/pacman.txt` の `docker` は Docker Desktop（Windows 側）を使う場合は不要
+- Nerd Font は Linux 内ではなく **Windows 側にインストール**する必要がある（Windows Terminal で使用する場合）
+- Neovim のクリップボード連携は `win32yank.exe` 経由（`.config/nvim/os/wsl.vim`）
+
+**Neovim プラグイン**
+
+install.sh 実行後、初回のみ以下を実行:
 
 ```bash
-code --list-extensions | xargs -L 1 echo code --install-extension
+nvim +PlugInstall +qall
 ```
 
-## Jupyter 設定
+`plugged/`（vim-plug）と `pack/`（copilot.vim 等）は `.gitignore` 対象のため自動生成される。
 
-`jupyter/` 配下のファイルを `~/.jupyter/` に配置します:
+**Nerd Font（WSL2 / Windows Terminal）**
+
+PowerShell で Windows 側にインストール:
+
+```powershell
+Invoke-WebRequest -Uri "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Hack.zip" -OutFile "$env:TEMP\Hack.zip"
+Expand-Archive "$env:TEMP\Hack.zip" -DestinationPath "$env:TEMP\HackNF" -Force
+$fontDest = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts"
+New-Item -ItemType Directory -Force -Path $fontDest | Out-Null
+$regPath = "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
+Get-ChildItem "$env:TEMP\HackNF\*.ttf" | ForEach-Object {
+    Copy-Item $_.FullName $fontDest -Force
+    Set-ItemProperty -Path $regPath -Name "$([System.IO.Path]::GetFileNameWithoutExtension($_.Name)) (TrueType)" -Value "$fontDest\$($_.Name)"
+}
+```
+
+Windows Terminal の `settings.json` にフォントを設定:
+
+```json
+{
+  "profiles": {
+    "defaults": {
+      "font": { "face": "Hack Nerd Font Mono" }
+    }
+  }
+}
+```
+
+## mise で管理するツール
+
+`~/.config/mise/config.toml` で宣言的に管理。`mise install` で一括インストール。
+
+| カテゴリ | ツール |
+|---|---|
+| 言語 | python / node / go / rust |
+| CLI ツール | neovim / tmux / bat / fd / delta / ripgrep / zoxide |
+| Git 関連 | lazygit / lazydocker |
+| シェル補助 | sheldon / atuin |
+| インフラ | kubectl / awscli / hurl |
+
+## direnv テンプレート
+
+プロジェクト用の `.envrc` をテンプレートから生成できる:
+
+```bash
+cd ~/projects/my-app
+envrc-new python   # python / node / go / rust から選択
+da                 # direnv allow で有効化
+```
+
+テンプレートは `files/.envrc.*.tpl` に格納。
+
+## tmux-sessionizer
+
+`Ctrl+F` でプロジェクト一覧（ghq 管理リポジトリ）を fzf で選択し、tmux session に自動接続:
+
+```bash
+# 前提: ghq で管理されているリポジトリが対象
+tmux-sessionizer          # fzf でプロジェクト選択
+tmux-sessionizer <path>   # パスを直接指定
+```
+
+## SSH 複数ホスト同時接続
+
+```bash
+bash msshrc/connect.sh host1 host2 host3   # 複数ホストに同時接続
+bash msshrc/connect_k.sh                   # k1〜k4 への一括接続
+```
+
+tmux セッションが作成され、全 pane に同時入力できる sync モードで起動する。
+
+## Jupyter 設定
 
 ```bash
 cp jupyter/jupyter_notebook_config.py ~/.jupyter/
@@ -107,16 +178,11 @@ mkdir -p ~/.jupyter/custom
 cp jupyter/custom.js ~/.jupyter/custom/
 ```
 
-保存時に自動的に Markdown と Python スクリプトに変換し、出力をクリアします (Git 管理向け)。
+保存時に自動で Markdown / Python スクリプトに変換し、出力をクリアする（Git 管理向け）。
 
-## SSH 複数ホスト同時接続
+## VS Code 拡張機能一覧の確認
 
 ```bash
-# ホスト名を引数で渡す
-bash msshrc/connect.sh host1 host2 host3
-
-# k1〜k4 への一括接続
-bash msshrc/connect_k.sh
+code --list-extensions | xargs -L 1 echo code --install-extension
 ```
 
-tmux セッションが作成され、全 pane に同時入力できる sync モードで起動します。

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ cd ~/dotfiles
 | .github | `~/.github -> .github` を symlink（Copilot 指示書） |
 | Copilot CLI skills | `~/.copilot/skills/*` を symlink |
 | diff-highlight | 条件を満たす場合 `diff-highlight` を `/usr/local/bin` に symlink |
-| GitHub CLI 拡張 | `gh-dash`（PR/Issue ダッシュボード）/ `gh-markdown-preview` をインストール |
 | mise install | `config.toml` に記載されたツールを一括インストール |
+| GitHub CLI 拡張 | `gh-dash`（PR/Issue ダッシュボード）/ `gh-markdown-preview` をインストール |
 
 ### インストール時の注意点
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Windows Terminal の `settings.json` にフォントを設定:
 | カテゴリ | ツール |
 |---|---|
 | 言語 | python / node / go / rust |
-| CLI ツール | neovim / tmux / bat / fd / delta / ripgrep / zoxide |
+| Python ツール | poetry |
+| CLI ツール | neovim / tmux / bat / fd / delta / ripgrep / zoxide / copilot |
 | Git 関連 | lazygit / lazydocker |
 | シェル補助 | sheldon / atuin |
 | インフラ | kubectl / awscli / hurl |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@
 │   └── snippet/             # VS Code スニペット
 ├── jupyter/                 # Jupyter Notebook 設定
 ├── msshrc/                  # 複数ホスト同時 SSH（tmux）
-└── sshrc/                   # リモート環境への設定持ち込み
+├── sshrc/                   # リモート環境への設定持ち込み（sshrc 本体）
+├── .sshrc                   # sshrc が参照する設定（install.sh が $HOME に symlink）
+└── .sshrc.d/                # sshrc で読み込まれる設定（install.sh が $HOME に symlink）
 ```
 
 ## セットアップ

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 ├── .github/
 │   ├── copilot-instructions.md  # GitHub Copilot 指示書（全リポジトリで自動適用）
 │   ├── prompts/                 # Copilot カスタムプロンプト
+│   ├── skills/                  # Copilot CLI Skills 定義
 │   └── workflows/               # GitHub Actions
 ├── vscode/
 │   ├── settings.json        # VS Code 設定

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd ~/dotfiles
 | ステップ | 内容 |
 |---|---|
 | OS パッケージ | `packages/*.txt` を参照し pacman / apt / brew で一括インストール |
-| dotfiles symlink | `.??*` の隠しファイル/ディレクトリを `$HOME` に symlink（`.git` `.github` `.codex` `.config` 除外） |
+| dotfiles symlink | `.??*` の隠しファイル/ディレクトリを `$HOME` に symlink（`.git` `.DS_Store` `.github` `.codex` `.config` 除外） |
 | bin/ symlink | `bin/*` を `~/bin/` に symlink |
 | Neovim | `~/.config/nvim/init.vim -> .vimrc`、`~/.config/nvim/os -> .config/nvim/os` を symlink |
 | mise | `~/.config/mise/config.toml` を symlink |
@@ -79,7 +79,11 @@ cd ~/dotfiles
 | atuin | `~/.config/atuin/config.toml` を symlink |
 | VS Code | `settings.json` / `keybindings.json` / スニペット / Copilot プロンプトを symlink |
 | .gitconfig | `.gitconfig.local` を `~/.gitconfig` にコピー |
+| IPython | `~/.ipython/.../ipython_config.py` を作成し Vim 編集モードを有効化 |
+| swap | `~/swap` を作成（Vim swap 用） |
 | .github | `~/.github -> .github` を symlink（Copilot 指示書） |
+| Copilot CLI skills | `~/.copilot/skills/*` を symlink |
+| diff-highlight | 条件を満たす場合 `diff-highlight` を `/usr/local/bin` に symlink |
 | GitHub CLI 拡張 | `gh-dash`（PR/Issue ダッシュボード）/ `gh-markdown-preview` をインストール |
 | mise install | `config.toml` に記載されたツールを一括インストール |
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cd ~/dotfiles
 
 **WSL2 環境**
 
-- `packages/pacman.txt` の `docker` は Docker Desktop（Windows 側）を使う場合は不要
+- `packages/pacman.txt` / `packages/apt.txt` の `docker`（apt は `docker.io`）は Docker Desktop（Windows 側）を使う場合は不要
 - Nerd Font は Linux 内ではなく **Windows 側にインストール**する必要がある（Windows Terminal で使用する場合）
 - Neovim のクリップボード連携は `win32yank.exe` 経由（`.config/nvim/os/wsl.vim`）
 


### PR DESCRIPTION
## 概要

README を現在の構成に合わせて全面再構成する。重複を排除し、最近追加した機能をすべて反映する。

## 変更内容

- ディレクトリ構成を現状に合わせて更新（bin/ packages/ .config/nvim/os/ files/ 等）
- install.sh の処理内容を表形式に整理
- インストール時の注意点を追加（WSL2・Nerd Font・Neovim PlugInstall）
- 新機能のセクションを追加
  - mise 管理ツール一覧
  - direnv テンプレート（envrc-new）
  - tmux-sessionizer
- 旧来の「必要なツール」表を削除（mise/packages で管理するため）
- 重複していた Jupyter / SSH セクションを整理統合