### PR TITLE
feat: WSL 環境で wslu を自動インストール

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,15 @@ elif command -v apt-get >/dev/null 2>&1; then
     echo "  installing: ${pkgs[*]}"
     run sudo apt-get install -y "${pkgs[@]}"
   fi
+  # WSL: wslu (wslview でブラウザ連携)
+  if grep -qi Microsoft /proc/version 2>/dev/null; then
+    if dpkg -s wslu >/dev/null 2>&1; then
+      echo "  (already installed: wslu)"
+    else
+      echo "  WSL detected: installing wslu..."
+      run sudo apt-get install -y wslu
+    fi
+  fi
   # Nerd Fonts: apt 非対応のため GitHub Release から取得
   font_dir="$HOME/.local/share/fonts"
   font_marker="$font_dir/HackNerdFont-Regular.ttf"


### PR DESCRIPTION
## 概要

WSL 環境で `gh dash` の `o` キーを押すと `wslview` が見つからないエラーが発生するため、`install.sh` で `wslu` を自動インストールするようにした。

## 変更内容

- [x] 機能追加

## 修正詳細

- `install.sh`: apt セクション内に WSL 判定を追加し、WSL 環境のみ `wslu` をインストール
  - `/proc/version` に `Microsoft` の文字列が含まれる場合を WSL と判定
  - 既インストール済みの場合はスキップ
  - macOS / 通常の Linux では実行されない

## レビューのポイント

- `wslu` に含まれる `wslview` が PATH に入ることで `gh dash` のブラウザ連携が機能する
- WSL 専用パッケージのため `packages/apt.txt` ではなく `install.sh` 内で個別処理した

## チェックリスト

- [x] 自分のコードの自己レビューを完了した
- [x] WSL 非環境での影響がないことを確認した
- [ ] テストを追加した