### PR TITLE
fix: preserve user git config by switching to include pattern

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -353,7 +353,7 @@ if command -v gh >/dev/null 2>&1; then
   opener="$HOME/bin/xdg-open"
   if [[ -f "$opener" ]]; then
     echo "  setting gh browser to: $opener"
-    run gh config set browser "bash $opener"
+    run gh config set browser "bash \"$opener\""
   else
     echo "  setting gh browser to: xdg-open"
     run gh config set browser xdg-open

--- a/install.sh
+++ b/install.sh
@@ -171,11 +171,12 @@ echo ""
 echo "==> Linking dotfiles to $HOME"
 cd "$SCRIPT_DIR"
 for f in .??*; do
-  [[ "$f" == ".git" ]]     && continue
-  [[ "$f" == ".DS_Store" ]] && continue
-  [[ "$f" == ".github" ]]   && continue
-  [[ "$f" == ".codex" ]]    && continue
-  [[ "$f" == ".config" ]]   && continue  # managed per-file below
+  [[ "$f" == ".git" ]]           && continue
+  [[ "$f" == ".DS_Store" ]]      && continue
+  [[ "$f" == ".github" ]]        && continue
+  [[ "$f" == ".codex" ]]         && continue
+  [[ "$f" == ".config" ]]        && continue  # managed per-file below
+  [[ "$f" == ".gitconfig.local" ]] && continue  # managed in Git config section below
   symlink "$SCRIPT_DIR/$f" "$HOME/$f"
 done
 
@@ -226,8 +227,35 @@ symlink "$SCRIPT_DIR/.config/atuin/config.toml" "$HOME/.config/atuin/config.toml
 # Git config
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> Copying .gitconfig.local -> ~/.gitconfig"
-run cp "$SCRIPT_DIR/.gitconfig.local" "$HOME/.gitconfig"
+echo "==> Linking .gitconfig.local -> ~/.gitconfig.local"
+symlink "$SCRIPT_DIR/.gitconfig.local" "$HOME/.gitconfig.local"
+
+echo "==> Ensuring ~/.gitconfig includes ~/.gitconfig.local"
+if ! "$DRY_RUN"; then
+  if [[ ! -f "$HOME/.gitconfig" ]]; then
+    cat > "$HOME/.gitconfig" <<'EOF'
+# User-specific settings (not managed by dotfiles)
+# Set your name and email here:
+# [user]
+#   name  = Your Name
+#   email = you@example.com
+
+[include]
+  path = ~/.gitconfig.local
+EOF
+    echo "  created ~/.gitconfig with [include] path = ~/.gitconfig.local"
+    echo "  NOTE: edit ~/.gitconfig to add your [user] name and email"
+  else
+    if ! grep -q 'path\s*=\s*~/.gitconfig.local' "$HOME/.gitconfig"; then
+      printf '\n[include]\n  path = ~/.gitconfig.local\n' >> "$HOME/.gitconfig"
+      echo "  appended [include] path = ~/.gitconfig.local to existing ~/.gitconfig"
+    else
+      echo "  (already includes ~/.gitconfig.local, skipping)"
+    fi
+  fi
+else
+  echo "[dry-run] would ensure ~/.gitconfig includes ~/.gitconfig.local"
+fi
 
 # ---------------------------------------------------------------------------
 # VS Code settings


### PR DESCRIPTION
install.sh 実行時に `.gitconfig.local` を `~/.gitconfig` に上書きコピーしていたため、`[user]` の name/email が消える問題を修正。

## 変更内容

- `.gitconfig.local` を `~/.gitconfig.local` にシンボリックリンク
- `~/.gitconfig` には `[include] path = ~/.gitconfig.local` を追記するだけにする
- `~/.gitconfig` が存在しない場合はテンプレートを自動生成
- `~/.gitconfig` が既に存在する場合は `[user]` 等のユーザー設定を保持したまま include を追記