### PR TITLE
feat(skills): adopt merge-worktrees integration branch pattern

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -3,6 +3,18 @@
 `.github/skills/` に配置された再利用可能なワークフロー集です。
 `/skill-name` で直接呼び出すか、自然言語で話しかけると自動的に読み込まれます。
 
+## ブランチ戦略
+
+```
+master          ←── PR ←── merge-worktrees
+                               ↑  ↑  ↑
+                        wt-A  wt-B wt-C  (git worktree)
+```
+
+- **feature ブランチ（worktree）**: 作業単位ごとに `git worktree add` で作成。`merge-worktrees` をベースにする
+- **`merge-worktrees`**: feature ブランチの統合ブランチ。完成した変更を `--squash` でマージして push
+- **`master`**: `merge-worktrees` からの PR 経由でのみ更新（直接コミット・push 禁止）
+
 ## ドキュメント
 
 | skill | 呼び出し例 | 概要 |

--- a/.github/skills/branch/SKILL.md
+++ b/.github/skills/branch/SKILL.md
@@ -33,7 +33,27 @@ git --no-pager branch --show-current
 git --no-pager branch -a | head -20
 ```
 
-通常は `main` または `master` をベースにする。別のブランチが指定されている場合はそちらを使用。
+ベースブランチは **`merge-worktrees`** を使用する。`merge-worktrees` が存在しない場合は `master` から作成する：
+
+```bash
+# merge-worktrees が存在しない場合
+git fetch origin
+git checkout -b merge-worktrees origin/master
+git push -u origin merge-worktrees
+```
+
+### 3. worktree の作成
+
+feature ブランチは `git worktree add` で作業ディレクトリごと作成する：
+
+```bash
+# merge-worktrees を最新にしてから worktree を作成
+git fetch origin
+git checkout merge-worktrees && git pull
+git worktree add ../<branch-name> -b <branch-name>
+```
+
+worktree のディレクトリ名は変更の目的を表す名前にする（例: `../worktree-add-zsh-alias`）。
 
 ### 3. ブランチ名の決定
 
@@ -78,16 +98,13 @@ hotfix/security-patch
 ### 5. ブランチ作成・切り替え
 
 ```bash
-# リモートの最新を取得してからブランチ作成
+# merge-worktrees を最新化
 git fetch origin
-git checkout -b <branch-name> origin/main
-```
+git checkout merge-worktrees && git pull
 
-または main が既にローカルに存在する場合：
-
-```bash
-git checkout main && git pull
-git checkout -b <branch-name>
+# worktree として新しい feature ブランチを作成
+git worktree add ../<branch-name> -b <branch-name>
+cd ../<branch-name>
 ```
 
 ### 6. 確認

--- a/.github/skills/commit-push/SKILL.md
+++ b/.github/skills/commit-push/SKILL.md
@@ -111,22 +111,37 @@ Co-authored-by トレーラーが必要な場合：
 git commit -m "<subject>" -m "<body>" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
 
-### 7. プッシュ実行
+### 7. merge-worktrees へマージして push
+
+feature ブランチの変更を `merge-worktrees` に取り込んでからリモートへ反映する：
 
 ```bash
-# 通常のプッシュ
-git push origin <branch-name>
+feature_branch=$(git branch --show-current)
 
-# 上流ブランチが未設定の場合（新規ブランチ）
-git push --set-upstream origin <branch-name>
+# メインリポジトリに戻って merge-worktrees を最新化
+cd <repo-root>
+git checkout merge-worktrees
+git pull origin merge-worktrees
+
+# feature ブランチをマージ（squash）
+git merge --squash "$feature_branch"
+git commit -m "<先ほどのコミットメッセージ>"
+
+# merge-worktrees をリモートへ push
+git push origin merge-worktrees
 ```
 
-#### プッシュ失敗時の対処
+```bash
+# worktree を後片付け
+git worktree remove ../<worktree-dir>
+git branch -d "$feature_branch"
+```
+
+#### push 失敗時の対処
 
 ```bash
-# リモートに新しいコミットがある場合（非破壊的な解決）
-git pull --rebase origin <branch-name>
-git push origin <branch-name>
+git pull --rebase origin merge-worktrees
+git push origin merge-worktrees
 ```
 
 ⚠️ `--force` / `--force-with-lease` はユーザーに明示的に確認を取った場合のみ使用する。

--- a/.github/skills/pull-request/SKILL.md
+++ b/.github/skills/pull-request/SKILL.md
@@ -21,31 +21,14 @@ description: |
 ### 1. 現在の状態確認
 
 ```bash
-git status
-git --no-pager log main..HEAD --oneline
+# merge-worktrees とデフォルトブランチの差分を確認
+git fetch origin
+git --no-pager log origin/master..origin/merge-worktrees --oneline
+git --no-pager diff origin/master...origin/merge-worktrees --stat
 ```
 
-未コミットの変更がある場合はユーザーに確認してから続行。
-
-**デフォルトブランチにいる場合は新しいブランチを作成する。**
-
-現在のブランチがデフォルトブランチ（`main` / `master`）と一致する場合は、
-コミット内容から適切なブランチ名を生成して切り替えてから PR を作成する。
-
-```bash
-# デフォルトブランチの確認
-default_branch=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
-current_branch=$(git branch --show-current)
-
-# デフォルトブランチにいる場合は新ブランチを作成
-if [ "$current_branch" = "$default_branch" ]; then
-  # コミット内容から <type>/<short-description> 形式でブランチ名を決める
-  git checkout -b <type>/<short-description>
-fi
-```
-
-ブランチ名の命名規則: `<type>/<kebab-case-description>`
-例: `feat/add-mise-config`、`fix/bash-display-guard`、`docs/update-readme`
+PR は常に **`merge-worktrees` → `master`** で作成する。
+feature ブランチから直接 PR を作成しない。
 
 ### 2. 差分の調査
 
@@ -104,13 +87,20 @@ Closes #<番号>
 ### 6. PR 作成
 
 ```bash
-# 通常PR
-gh pr create --title "<タイトル>" --body "<本文>" --base main
+# merge-worktrees -> master への PR
+gh pr create \
+  --base master \
+  --head merge-worktrees \
+  --title "<タイトル>" \
+  --body "<本文>"
 
 # ドラフトPR
-gh pr create --title "<タイトル>" --body "<本文>" --base main --draft
-
-# Issue に紐づける場合（本文に Closes #番号 を含めれば自動でリンク）
+gh pr create \
+  --base master \
+  --head merge-worktrees \
+  --title "<タイトル>" \
+  --body "<本文>" \
+  --draft
 ```
 
 ### 作成のポイント


### PR DESCRIPTION
## 概要
スキルのブランチ戦略を統一し、feature ブランチから直接 master へ PR を出す運用を廃止。

## ブランチ戦略
```
master  <-- PR <-- merge-worktrees
                       ^  ^  ^
                  wt-A wt-B wt-C  (git worktree)
```

## 変更内容
- `branch`: worktree を `merge-worktrees` ベースで作成する手順に変更
- `commit-push`: push 先を `merge-worktrees` に変更（feature ブランチから直接 push しない）
- `pull-request`: PR は `merge-worktrees` -> `master` で作成するよう変更
- `README`: ブランチ戦略の概要図を追加