### PR TITLE
fix(skills): add empty check and anchored sed for default_branch

### DIFF
--- a/.github/skills/pull-request/SKILL.md
+++ b/.github/skills/pull-request/SKILL.md
@@ -26,7 +26,12 @@ description: |
 
 ```bash
 # デフォルトブランチを取得
-default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+
+if [ -z "$default_branch" ]; then
+  echo "デフォルトブランチを取得できませんでした"
+  exit 1
+fi
 
 # merge-worktrees とデフォルトブランチの差分を確認
 git fetch origin
@@ -35,6 +40,7 @@ git --no-pager diff "origin/${default_branch}...origin/merge-worktrees" --stat
 ```
 
 PR は常に **`merge-worktrees` → デフォルトブランチ** で作成する。
+`merge-worktrees` がデフォルトブランチから作成・更新されていることを確認する。
 feature ブランチから直接 PR を作成しない。
 
 ### 2. 差分の調査
@@ -95,7 +101,12 @@ Closes #<番号>
 
 ```bash
 # デフォルトブランチを取得
-default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+
+if [ -z "$default_branch" ]; then
+  echo "デフォルトブランチを取得できませんでした"
+  exit 1
+fi
 
 # merge-worktrees -> デフォルトブランチへの PR
 gh pr create \


### PR DESCRIPTION
## 概要
pull-request スキルの default_branch 取得処理を堅牢化。
sed を先頭一致パターンに変更し、空文字チェックを追加。

## 変更内容
- [x] バグ修正

## 修正詳細
- `sed 's|refs/remotes/origin/||'` → `sed 's@^refs/remotes/origin/@@'`（先頭一致で誤置換を防止）
- `default_branch` が空の場合にエラーメッセージを出して中断するガードを追加（手順1・手順6）
- `merge-worktrees` がデフォルトブランチから作成・更新されていることを確認する旨を追記

## チェックリスト
- [x] 自分のコードの自己レビューを完了した